### PR TITLE
Ping'ed Numpy to 1.11.0 as latest version 1.12.x is not compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,5 +148,5 @@ setuptools.setup(
     license = 'BSD',
     package_data = package_data,
     include_package_data = True,
-    install_requires = ['numpy', 'scipy', 'nose', 'hyperopt', 'scikit-learn'],
+    install_requires = ['NumPy==1.11.0', 'scipy', 'nose', 'hyperopt', 'scikit-learn'],
 )


### PR DESCRIPTION
- Pin'ed Numpy to 1.11.0 as latest version 1.12.x is not compatible
- Added missing Dependencies in notebook Demo-Iris