### PR TITLE
Fix networkx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ setuptools.setup(
     package_data = package_data,
     include_package_data = True,
     install_requires = [
+        'networkx==1.11',
         'hyperopt',
         'nose',
         'NumPy==1.11.0',


### PR DESCRIPTION
This fix specifies a dependency on an earlier version (1.11) of `networkx`. This should be considered a temporary fix until hyperopt creates a new pip release. 