### PR TITLE
Fix to crossvalidation and test

### DIFF
--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -362,7 +362,9 @@ def _cost_fn(argd, X, y, EX_list, valid_size, n_folds, shuffle, random_state,
                 'ex_preprocs': ex_pps_list,
                 'status': hyperopt.STATUS_OK,
                 'duration': t_done - t_start,
-                'iterations': cv_n_iters.max(),
+                'iterations': (cv_n_iters.max()
+                    if (hasattr(learner, "partial_fit") and use_partial_fit)
+                    else None),
             }
             rtype = 'return'
         # The for loop exit with break, one fold did not finish running.

--- a/hpsklearn/tests/test_estimator.py
+++ b/hpsklearn/tests/test_estimator.py
@@ -136,3 +136,25 @@ def test_continuous_loss_fn():
 #         model.fit(self.X, self.Y)
 
 # -- flake8 eof
+
+def test_crossvalidation():
+    """
+    Demonstrate performing a k-fold CV using the fit() method.
+    """
+    # Generate some random data
+    X = np.hstack([
+        np.vstack([
+            np.random.normal(0,1,size=(1000,10)),
+            np.random.normal(1,1,size=(1000,10)),
+        ]),
+        np.random.normal(0,1,size=(2000,10)),
+    ])
+    y = np.zeros(2000)
+    y[:1000] = 1
+
+    # Try to fit a model
+    cls = hyperopt_estimator(
+        classifier=components.random_forest('forest'),
+        preprocessing=[],
+    )
+    cls.fit(X,y,cv_shuffle=True, n_folds=5)

--- a/hpsklearn/tests/test_estimator.py
+++ b/hpsklearn/tests/test_estimator.py
@@ -154,7 +154,7 @@ def test_crossvalidation():
 
     # Try to fit a model
     cls = hyperopt_estimator(
-        classifier=components.random_forest('forest'),
+        classifier=components.sgd('sgd', loss='log'),
         preprocessing=[],
     )
     cls.fit(X,y,cv_shuffle=True, n_folds=5)


### PR DESCRIPTION
Using the CV options without `use_partial_fit` causes an error because `cv_n_iters` gets filled with `None`, which can't be passed to `max()`.  This is a patch that fixes this, along with a test that used to fail, but now doesn't.