### PR TITLE
Cleanup setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 setup(
-    name = "hyperopt-sklearn",
+    name = "hpsklearn",
     version = '0.0.3',
     packages = find_packages(),
     scripts = [],

--- a/setup.py
+++ b/setup.py
@@ -1,129 +1,21 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-""" distribute- and pip-enabled setup.py """
-
 import logging
 import os
 
-# ----- overrides -----
-
-# set these to anything but None to override the automatic defaults
-packages = None
-package_name = None
-package_data = None
-scripts = None
-# ---------------------
-
-
-# ----- control flags -----
-
-# fallback to setuptools if distribute isn't found
-setup_tools_fallback = True
-
-# don't include subdir named 'tests' in package_data
-skip_tests = False
-
-# print some extra debugging info
-debug = True
-
-# -------------------------
-
-if debug: logging.basicConfig(level=logging.DEBUG)
-# distribute import and testing
 try:
-    import distribute_setup
-    distribute_setup.use_setuptools()
-    logging.debug("distribute_setup.py imported and used")
+    import setuptools
+    from setuptools import find_packages, setup
 except ImportError:
-    # fallback to setuptools?
-    # distribute_setup.py was not in this directory
-    if not (setup_tools_fallback):
-        import setuptools
-        if not (hasattr(setuptools,'_distribute') and \
-                setuptools._distribute):
-            raise ImportError("distribute was not found and fallback to setuptools was not allowed")
-        else:
-            logging.debug("distribute_setup.py not found, defaulted to system distribute")
-    else:
-        logging.debug("distribute_setup.py not found, defaulting to system setuptools")
+    raise ImportError(
+        "'setuptools' is required but not installed. To install it, "
+        "follow the instructions at "
+        "https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py")
 
-import setuptools
 
-def find_scripts():
-    return [s for s in setuptools.findall('scripts/') if os.path.splitext(s)[1] != '.pyc']
-
-def package_to_path(package):
-    """
-    Convert a package (as found by setuptools.find_packages)
-    e.g. "foo.bar" to usable path
-    e.g. "foo/bar"
-
-    No idea if this works on windows
-    """
-    return package.replace('.','/')
-
-def find_subdirectories(package):
-    """
-    Get the subdirectories within a package
-    This will include resources (non-submodules) and submodules
-    """
-    try:
-        subdirectories = next(os.walk(package_to_path(package)))[1]
-    except StopIteration:
-        subdirectories = []
-    return subdirectories
-
-def subdir_findall(dir, subdir):
-    """
-    Find all files in a subdirectory and return paths relative to dir
-
-    This is similar to (and uses) setuptools.findall
-    However, the paths returned are in the form needed for package_data
-    """
-    strip_n = len(dir.split('/'))
-    path = '/'.join((dir, subdir))
-    return ['/'.join(s.split('/')[strip_n:]) for s in setuptools.findall(path)]
-
-def find_package_data(packages):
-    """
-    For a list of packages, find the package_data
-
-    This function scans the subdirectories of a package and considers all
-    non-submodule subdirectories as resources, including them in
-    the package_data
-
-    Returns a dictionary suitable for setup(package_data=<result>)
-    """
-    package_data = {}
-    for package in packages:
-        package_data[package] = []
-        for subdir in find_subdirectories(package):
-            if '.'.join((package, subdir)) in packages: # skip submodules
-                logging.debug("skipping submodule %s/%s" % (package, subdir))
-                continue
-            if skip_tests and (subdir == 'tests'): # skip tests
-                logging.debug("skipping tests %s/%s" % (package, subdir))
-                continue
-            package_data[package] += subdir_findall(package_to_path(package), subdir)
-    return package_data
-
-# ----------- Override defaults here ----------------
-if packages is None: packages = setuptools.find_packages()
-
-if len(packages) == 0: raise Exception("No valid packages found")
-
-if package_name is None: package_name = packages[0]
-
-if package_data is None: package_data = find_package_data(packages)
-
-if scripts is None: scripts = find_scripts()
-
-setuptools.setup(
-    name = package_name,
+setup(
+    name = "hyperopt-sklearn",
     version = '0.0.3',
-    packages = packages,
-    scripts = scripts,
+    packages = find_packages(),
+    scripts = [],
     url = 'http://hyperopt.github.com/hyperopt-sklearn/',
     download_url = 'https://github.com/hyperopt/hyperopt-sklearn/archive/0.0.3.tar.gz',
     author = 'James Bergstra',
@@ -148,8 +40,6 @@ setuptools.setup(
     ],
     platforms = ['Linux', 'OS-X', 'Windows'],
     license = 'BSD',
-    package_data = package_data,
-    include_package_data = True,
     install_requires = [
         'hyperopt',
         'nose',


### PR DESCRIPTION
Modernizes `setup.py` so that it's compatible with Windows and is less complex.

Simlar to #81, I was also having trouble installing on Windows 10 with Python 3.6. Specifically, I was getting the error:

```
PS C:\Users\mr_bo\git\hyperopt-sklearn> pip install -e .
Obtaining file:///C:/Users/mr_bo/git/hyperopt-sklearn
    Complete output from command python setup.py egg_info:
    Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.38.tar.gz
    Traceback (most recent call last):
      File "c:\users\mr_bo\git\hyperopt\distribute_setup.py", line 150, in use_setuptools
        raise ImportError
    ImportError

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\mr_bo\git\hyperopt-sklearn\setup.py", line 36, in <module>
        distribute_setup.use_setuptools()
      File "c:\users\mr_bo\git\hyperopt\distribute_setup.py", line 152, in use_setuptools
        return _do_download(version, download_base, to_dir, download_delay)
      File "c:\users\mr_bo\git\hyperopt\distribute_setup.py", line 131, in _do_download
        to_dir, download_delay)
      File "c:\users\mr_bo\git\hyperopt\distribute_setup.py", line 201, in download_setuptools
        src = urlopen(url)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 223, in urlopen
        return opener.open(url, data, timeout)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 532, in open
        response = meth(req, response)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 642, in http_response
        'http', request, response, code, msg, hdrs)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 570, in error
        return self._call_chain(*args)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 504, in _call_chain
        result = func(*args)
      File "c:\tools\anaconda3\lib\urllib\request.py", line 650, in http_error_default
        raise HTTPError(req.full_url, code, msg, hdrs, fp)
    urllib.error.HTTPError: HTTP Error 403: SSL is required

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\mr_bo\git\hyperopt-sklearn\
```

However, when I deleted the chunk:
```
if debug: logging.basicConfig(level=logging.DEBUG)
# distribute import and testing
try:
    import distribute_setup
    distribute_setup.use_setuptools()
    logging.debug("distribute_setup.py imported and used")
except ImportError:
    # fallback to setuptools?
    # distribute_setup.py was not in this directory
    if not (setup_tools_fallback):
        import setuptools
        if not (hasattr(setuptools,'_distribute') and \
                setuptools._distribute):
            raise ImportError("distribute was not found and fallback to setuptools was not allowed")
        else:
            logging.debug("distribute_setup.py not found, defaulted to system distribute")
    else:
        logging.debug("distribute_setup.py not found, defaulting to system setuptools")
```

from `setup.py`, I was able to install the package. Consequently, I've created this PR to clean up `setup.py`.

I decided to copy Nengo's style of `setup.py`. Nengo has stringent setup requirements and it:
- Doesn't use any of the tools I removed.
-  [Explicitly throws an error if `setuptools` can't be found](https://github.com/nengo/nengo/blob/master/setup.py#L7).
 - Doesn't bother with `include_package_data`, which seems to be something which [should be replaced with Manifest.in anyways](https://stackoverflow.com/q/7522250/1079075).