### PR TITLE
using integers to match new sklearn decision tree parameters

### DIFF
--- a/hpsklearn/components.py
+++ b/hpsklearn/components.py
@@ -1019,12 +1019,12 @@ def decision_tree(name,
             ['sqrt', 'log2',
              None]) if max_features is None else max_features,
         max_depth=max_depth,
-        min_samples_split=hp.quniform(
+        min_samples_split=scope.int(hp.quniform(
             _name('min_samples_split'),
-            1, 10, 1) if min_samples_split is None else min_samples_split,
-        min_samples_leaf=hp.quniform(
+            1, 10, 1)) if min_samples_split is None else min_samples_split,
+        min_samples_leaf=scope.int(hp.quniform(
             _name('min_samples_leaf'),
-            1, 5, 1) if min_samples_leaf is None else min_samples_leaf,
+            1, 5, 1)) if min_samples_leaf is None else min_samples_leaf,
         presort=presort,
         random_state=_random_state(_name('rstate'), random_state),
         )


### PR DESCRIPTION
sklearn version 0.18 changed the `min_samples_leaf` and `min_samples_split` parameters of `sklearn.tree.DecisionTreeClassifier` to function differently if given integers or floats. Casting the default search space to integer to match old behaviour and prevent errors.