### PR TITLE
Adding a any_sparse_preprocessing function and testing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ colkmeans
 
 For a simple generic search space across many preprocessing algorithms, use `any_preprocessing`.
 If you are working with raw text data, use `any_text_preprocessing`.
+If you are working with sparse input, use `any_sparse_preprocessing`.
 Currently only TFIDF is used for text, but more may be added in the future.
 Note that the `preprocessing` parameter in `HyperoptEstimator` is expecting a list, since various preprocessing steps can be chained together.
 The generic search space functions `any_preprocessing` and `any_text_preprocessing` already return a list, but the others do not so they should be wrapped in a list.

--- a/hpsklearn/components.py
+++ b/hpsklearn/components.py
@@ -1855,6 +1855,21 @@ def any_text_preprocessing(name):
         [tfidf(name + '.tfidf')],
     ])
 
+def any_sparse_preprocessing(name):
+    """
+    Preprocessors that support sparse input.
+    * missing pca
+    * missing min_max_scaler
+    * missing one_hot_encoder (because it's also not in any_preprocessing)
+    * standard_scaler has with_mean=False, at the recommendation of the sklearn
+      error message
+    """
+    return hp.choice('%s' % name, [
+        [standard_scaler(name + '.standard_scaler', with_mean=False)],
+        [normalizer(name + '.normalizer')],
+        []
+    ])
+
 
 ##############################################################
 ##==== Generic hyperparameters search space constructor ====##

--- a/hpsklearn/tests/test_estimator.py
+++ b/hpsklearn/tests/test_estimator.py
@@ -82,7 +82,7 @@ def test_sparse_input():
     # Try to fit an SGD model
     cls = hyperopt_estimator(
         classifier=components.sgd('sgd', loss='log'),
-        preprocessing=[],
+        preprocessing=components.any_sparse_preprocessing('preproc'),
     )
     cls.fit(X,y)
 


### PR DESCRIPTION
Fix for a problem raised in issue #132 .  Add an `any_sparse_preprocessing` component that only includes preprocessors that can handle sparse input.