### PR TITLE
Add parameter n_jobs for multiprocessing to hyperopt_estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ estim.fit(X_train, y_train)
 Complete example using the Iris dataset:
 
 ```python
-from hpsklearn import HyperoptEstimator, any_classifier
+from hpsklearn import HyperoptEstimator, any_classifier, any_preprocessing
 from sklearn.datasets import load_iris
 from hyperopt import tpe
 import numpy as np

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ estim.fit(X_train, y_train)
 print(estim.score(X_test, y_test))
 # 1.0
 
-print( estim.best_model() )
+print(estim.best_model())
 # {'learner': ExtraTreesClassifier(bootstrap=False, class_weight=None, criterion='gini',
 #           max_depth=3, max_features='log2', max_leaf_nodes=None,
 #           min_impurity_decrease=0.0, min_impurity_split=None,

--- a/hpsklearn/components.py
+++ b/hpsklearn/components.py
@@ -1383,7 +1383,7 @@ def _lightgbm_max_depth(name):
     return scope.int(hp.uniform(name, 1, 11))
 
 def _lightgbm_num_leaves(name):
-    return scope.int(hp.uniform(name, 1, 121))
+    return scope.int(hp.uniform(name, 2, 121))
 
 def _lightgbm_learning_rate(name):
     return hp.loguniform(name, np.log(0.0001), np.log(0.5)) - 0.0001
@@ -1435,14 +1435,12 @@ def _lightgbm_hp_space(
     hp_space = dict(
         max_depth=(_lightgbm_max_depth(name_func('max_depth'))
                    if max_depth is None else max_depth),
-        num_leaves=min((_lightgbm_num_leaves(name_func('num_leaves'))
-        if num_leaves is None else num_leaves), 2**max_depth),
+        num_leaves=(_lightgbm_num_leaves(name_func('num_leaves'))
+                    if num_leaves is None else num_leaves),
         learning_rate=(_lightgbm_learning_rate(name_func('learning_rate'))
                        if learning_rate is None else learning_rate),
         n_estimators=(_lightgbm_n_estimators(name_func('n_estimators'))
                       if n_estimators is None else n_estimators),
-        gamma=(_lightgbm_gamma(name_func('gamma'))
-               if gamma is None else gamma),
         min_child_weight=(_lightgbm_min_child_weight(name_func('min_child_weight'))
                           if min_child_weight is None else min_child_weight),
         max_delta_step=max_delta_step,
@@ -1450,8 +1448,6 @@ def _lightgbm_hp_space(
                    if subsample is None else subsample),
         colsample_bytree=(_lightgbm_colsample_bytree(name_func('colsample_bytree'))
                           if colsample_bytree is None else colsample_bytree),
-        colsample_bylevel=(_lightgbm_colsample_bylevel(name_func('colsample_bylevel'))
-                          if colsample_bylevel is None else colsample_bylevel),
         reg_alpha=(_lightgbm_reg_alpha(name_func('reg_alpha'))
                    if reg_alpha is None else reg_alpha),
         reg_lambda=(_lightgbm_reg_lambda(name_func('reg_lambda'))
@@ -1459,7 +1455,6 @@ def _lightgbm_hp_space(
         boosting_type=(_lightgbm_boosting_type(name_func('boosting_type'))
                     if boosting_type is None else boosting_type),
         scale_pos_weight=scale_pos_weight,
-        base_score=base_score,
         seed=_random_state(name_func('rstate'), random_state)
     )
     return hp_space
@@ -1483,7 +1478,6 @@ def lightgbm_classification(name, objective='binary', **kwargs):
         return '%s.%s_%s' % (name, 'lightgbm', msg)
 
     hp_space = _lightgbm_hp_space(_name, **kwargs)
-    import pdb; pdb.set_trace()
     hp_space['objective'] = objective
     return scope.sklearn_LGBMClassifier(**hp_space)
 

--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -532,6 +532,7 @@ class hyperopt_estimator(BaseEstimator):
         self._best_learner = None
         self._best_loss = None
         self._best_iters = None
+	self.n_jobs = n_jobs
         if space is None:
             if classifier is None and regressor is None:
                 self.classification = True

--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -225,6 +225,10 @@ def _cost_fn(argd, X, y, EX_list, valid_size, n_folds, shuffle, random_state,
             preprocessings = argd['model']['preprocessing']
             ex_pps_list = argd['model']['ex_preprocs']
         learner = classifier if classifier is not None else regressor
+        # Set n_jobs parameter if available for given learner
+        if hasattr(learner, 'n_jobs'):
+            # https://github.com/hyperopt/hyperopt-sklearn/issues/82#issuecomment-430963445
+            learner.n_jobs = n_jobs
         is_classif = classifier is not None
         untrained_learner = copy.deepcopy(learner)
         # -- N.B. modify argd['preprocessing'] in-place
@@ -329,9 +333,6 @@ def _cost_fn(argd, X, y, EX_list, valid_size, n_folds, shuffle, random_state,
                 n_iters = None
             if learner is None:
                 break
-            elif hasattr(learner, 'n_jobs'):
-                # https://github.com/hyperopt/hyperopt-sklearn/issues/82#issuecomment-430963445
-                learner.n_jobs = n_jobs
             cv_y_pool = np.append(cv_y_pool, yval)
             info('Scoring on X/EX validation of shape', XEXval.shape)
             if continuous_loss_fn:

--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -604,15 +604,12 @@ class hyperopt_estimator(BaseEstimator):
         assert weights is None
         increment = self.fit_increment if increment is None else increment
 
-        # len does not work on sparse matrices, so using shape[0] instead
-        # shape[0] does not work on lists, so using len() for those
-        if scipy.sparse.issparse(X):
-            data_length = X.shape[0]
-        else:
-            data_length = len(X)
-        if type(X) is list:
+        # Convert list, pandas series, or other array-like to ndarray
+        # do not convert sparse matrices
+        if not scipy.sparse.issparse(X) and not isinstance(X, np.ndarray):
             X = np.array(X)
-        if type(y) is list:
+
+        if not scipy.sparse.issparse(y) and not isinstance(y, np.ndarray):
             y = np.array(y)
 
         if not warm_start:

--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -57,7 +57,8 @@ class NonFiniteFeature(Exception):
     """
 
 def transform_combine_XEX(Xfit, info, en_pps=[], Xval=None, 
-                          EXfit_list=None, ex_pps_list=[], EXval_list=None):
+                          EXfit_list=None, ex_pps_list=[], EXval_list=None,
+                          fit_preproc=True):
     '''Transform endogenous and exogenous datasets and combine them into a 
     single dataset for training and testing.
     '''
@@ -72,7 +73,8 @@ def transform_combine_XEX(Xfit, info, en_pps=[], Xval=None,
                 n_components = min([n_components] + list(Xfit.shape))
                 pp_algo.set_params(n_components=n_components)
                 info('Limited PCA n_components at', n_components)
-            pp_algo.fit(Xfit)
+            if fit_preproc:
+                pp_algo.fit(Xfit)
             info('Transforming Xfit', Xfit.shape)
             Xfit = pp_algo.transform(Xfit)
             # np.isfinite() does not work on sparse matrices
@@ -788,7 +790,7 @@ class hyperopt_estimator(BaseEstimator):
         if self.refit:
             self.retrain_best_model_on_full_data(X, y, EX_list, weights)
 
-    def predict(self, X, EX_list=None):
+    def predict(self, X, EX_list=None, fit_preproc=False):
         """
         Use the best model found by previous fit() to make a prediction.
         """
@@ -804,11 +806,12 @@ class hyperopt_estimator(BaseEstimator):
             X = np.array(X)
         XEX = transform_combine_XEX(
             X, self.info, en_pps=self._best_preprocs, 
-            EXfit_list=EX_list, ex_pps_list=self._best_ex_preprocs
+            EXfit_list=EX_list, ex_pps_list=self._best_ex_preprocs,
+            fit_preproc=fit_preproc,
         )
         return self._best_learner.predict(XEX)
 
-    def score(self, X, y, EX_list=None):
+    def score(self, X, y, EX_list=None, fit_preproc=False):
         """
         Return the score (accuracy or R2) of the learner on 
         a given set of data
@@ -825,7 +828,8 @@ class hyperopt_estimator(BaseEstimator):
             X = np.array(X)
         XEX = transform_combine_XEX(
             X, self.info, en_pps=self._best_preprocs, 
-            EXfit_list=EX_list, ex_pps_list=self._best_ex_preprocs
+            EXfit_list=EX_list, ex_pps_list=self._best_ex_preprocs,
+            fit_preproc=fit_preproc,
         )
         return self._best_learner.score(XEX, y)
 

--- a/hpsklearn/tests/test_classification.py
+++ b/hpsklearn/tests/test_classification.py
@@ -119,6 +119,19 @@ if xgboost is not None:
         create_function(components.xgboost_classification)
     )
 
+# Only test the lightgbm classifier if the optional dependency is installed
+try:
+    import lightgbm
+except ImportError:
+    lightgbm = None
+
+if lightgbm is not None:
+    setattr(
+        TestClassification,
+        'test_{0}'.format(clf.__name__),
+        create_function(components.lightgbm_classification)
+    )
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/hpsklearn/tests/test_classification.py
+++ b/hpsklearn/tests/test_classification.py
@@ -115,7 +115,7 @@ except ImportError:
 if xgboost is not None:
     setattr(
         TestClassification,
-        'test_{0}'.format(clf.__name__),
+        'test_xgboost_classification',
         create_function(components.xgboost_classification)
     )
 
@@ -128,7 +128,7 @@ except ImportError:
 if lightgbm is not None:
     setattr(
         TestClassification,
-        'test_{0}'.format(clf.__name__),
+        'test_lightgbm_classification',
         create_function(components.lightgbm_classification)
     )
 

--- a/hpsklearn/tests/test_regression.py
+++ b/hpsklearn/tests/test_regression.py
@@ -69,7 +69,7 @@ except ImportError:
 if xgboost is not None:
     setattr(
         TestRegression,
-        'test_{0}'.format(clf.__name__),
+        'test_xgboost_regression',
         create_function(components.xgboost_regression)
     )
 
@@ -82,7 +82,7 @@ except ImportError:
 if lightgbm is not None:
     setattr(
         TestRegression,
-        'test_{0}'.format(clf.__name__),
+        'test_lightgmb_regression',
         create_function(components.lightgbm_regression)
     )
 

--- a/hpsklearn/tests/test_regression.py
+++ b/hpsklearn/tests/test_regression.py
@@ -73,6 +73,19 @@ if xgboost is not None:
         create_function(components.xgboost_regression)
     )
 
+# Only test the lightgbm regressor if the optional dependency is installed
+try:
+    import lightgbm
+except ImportError:
+    lightgbm = None
+
+if lightgbm is not None:
+    setattr(
+        TestRegression,
+        'test_{0}'.format(clf.__name__),
+        create_function(components.lightgbm_regression)
+    )
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'scipy',
     ],
     extras_require = {
-        'xgboost':  ['xgboost==0.6a2']
+        'xgboost':  ['xgboost==0.6a2'],
+        'lightgbm': ['lightgbm==2.3.1']
     }
 )


### PR DESCRIPTION
Hi, this PR addresses the discussion in issue https://github.com/hyperopt/hyperopt-sklearn/issues/82 and especially comment https://github.com/hyperopt/hyperopt-sklearn/issues/82#issuecomment-430963445. 

To support (at least some) multiprocessing, I added the well-known sklearn/joblib parameter n_jobs to the hyperopt_estimator function. Whenever an estimator is called which supports multiprocessing, it is passed n_jobs as argument:

`estim = hpsklearn.HyperoptEstimator(..., n_jobs=2)`

Two caveats: First, for smaller data sets, this rather slows some sklearn functions down due to parallelization overhead (cf. e.g. https://github.com/scikit-learn/scikit-learn/issues/6645 or https://github.com/scikit-learn/scikit-learn/issues/8216). However, a quick analysis showed that for larger datasets there may be some benefit by using multiple cores: 

![Figure_1](https://user-images.githubusercontent.com/29574653/63217544-2095b900-c148-11e9-858e-e0bd11619b1b.png)

Legend: Color encodes number of samples for a dummy sklearn.datasets.make_classification task. y-axis shows time needed to perform 30 evals relative to time with one core. Random seeds were set to ensure that hyperopt runs were identical. Repetitions would be needed for reliable time estimates etc. but this should be enough for demonstration purposes.

Second, it would be nice to parallelize the cross-validation part in _cost_fn but there is an interesting for-else statement that I could not handle using joblib... :) Suggestions are welcome.

I'm happy for ideas how to improve this PR. In case this PR should not be merged, that's perfectly fine, too. Thanks and best!
