### PR TITLE
converting X and y to numpy array in fit

### DIFF
--- a/hpsklearn/estimator.py
+++ b/hpsklearn/estimator.py
@@ -604,15 +604,12 @@ class hyperopt_estimator(BaseEstimator):
         assert weights is None
         increment = self.fit_increment if increment is None else increment
 
-        # len does not work on sparse matrices, so using shape[0] instead
-        # shape[0] does not work on lists, so using len() for those
-        if scipy.sparse.issparse(X):
-            data_length = X.shape[0]
-        else:
-            data_length = len(X)
-        if type(X) is list:
+        # Convert list, pandas series, or other array-like to ndarray
+        # do not convert sparse matrices
+        if not scipy.sparse.issparse(X) and not isinstance(X, np.ndarray):
             X = np.array(X)
-        if type(y) is list:
+
+        if not scipy.sparse.issparse(y) and not isinstance(y, np.ndarray):
             y = np.array(y)
 
         if not warm_start:


### PR DESCRIPTION
* converting X and y to a numpy array if not already an array or sparse matrix. Allows a user to pandas dataframe or series without needing to explicitly convert it themselves.
* removing some obsolete code

Addresses #147 and a start to #122 