### PR TITLE
Update Demo-Iris notebook

### DIFF
--- a/notebooks/Demo-Iris.ipynb
+++ b/notebooks/Demo-Iris.ipynb
@@ -1,155 +1,162 @@
 {
- "metadata": {
-  "name": "Demo-Iris"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hyperopt-Sklearn on Iris\n",
+    "\n",
+    "`Iris` is a small data set of 150 examples of flower attributes and types of Iris.\n",
+    "\n",
+    "The small size of Iris means that hyperparameter optimization takes just a few seconds.\n",
+    "On the other hand, Iris is so *easy* that we'll typically see numerous near-perfect models within the first few random guesses; hyperparameter optimization algorithms are hardly necessary at all.\n",
+    "\n",
+    "Nevertheless, here is how to use hyperopt-sklearn (`hpsklearn`) to find a good model of the Iris data set. The code walk-through is given in 5 steps:\n",
+    "\n",
+    "  1. module imports\n",
+    "  2. data preparation into training and testing sets for a single fold of cross-validation.\n",
+    "  3. creation of a hpsklearn `HyperoptEstimator`\n",
+    "  4. a somewhat spelled-out version of `HyperoptEstimator.fit`\n",
+    "  5. inspecting and testing the best model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IMPORTS\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.datasets import load_iris\n",
+    "import hpsklearn\n",
+    "import hpsklearn.demo_support\n",
+    "import hyperopt.tpe\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# PREPARE TRAINING AND TEST DATA\n",
+    "iris = load_iris()\n",
+    "df_iris = pd.DataFrame(iris.data, columns=iris.feature_names)\n",
+    "df_iris['species_name'] = pd.Categorical.from_codes(iris.target, iris.target_names)\n",
+    "y = df_iris['species_name']\n",
+    "X = df_iris.drop(['species_name'], axis=1)\n",
+    "\n",
+    "# TRAIN AND TEST DATA\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator = hpsklearn.HyperoptEstimator(\n",
+    "    preprocessing=hpsklearn.components.any_preprocessing('pp'),\n",
+    "    classifier=hpsklearn.components.any_classifier('clf'),\n",
+    "    algo=hyperopt.tpe.suggest,\n",
+    "    trial_timeout=15.0, # seconds\n",
+    "    max_evals=15,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Hyperopt-Sklearn on Iris\n",
-      "\n",
-      "`Iris` is a small data set of 150 examples of flower attributes and types of Iris.\n",
-      "\n",
-      "The small size of Iris means that hyperparameter optimization takes just a few seconds.\n",
-      "On the other hand, Iris is so *easy* that we'll typically see numerous near-perfect models within the first few random guesses; hyperparameter optimization algorithms are hardly necessary at all.\n",
-      "\n",
-      "Nevertheless, here is how to use hyperopt-sklearn (`hpsklearn`) to find a good model of the Iris data set. The code walk-through is given in 5 steps:\n",
-      "\n",
-      "  1. module imports\n",
-      "  2. data preparation into training and testing sets for a single fold of cross-validation.\n",
-      "  3. creation of a hpsklearn `HyperoptEstimator`\n",
-      "  4. a somewhat spelled-out version of `HyperoptEstimator.fit`\n",
-      "  5. inspecting and testing the best model"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# IMPORTS\n",
-      "import numpy as np\n",
-      "import skdata.iris.view\n",
-      "import hyperopt.tpe\n",
-      "import hpsklearn\n",
-      "import hpsklearn.demo_support\n",
-      "import time"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# PREPARE TRAINING AND TEST DATA\n",
-      "data_view = skdata.iris.view.KfoldClassification(4)\n",
-      "attrs = 'petal_length', 'petal_width', 'sepal_length', 'sepal_width'\n",
-      "labels = 'setosa', 'versicolor', 'virginica'\n",
-      "X_all = np.asarray([map(d.__getitem__, attrs) for d in data_view.dataset.meta])\n",
-      "y_all = np.asarray([labels.index(d['name']) for d in data_view.dataset.meta])\n",
-      "idx_all = np.random.RandomState(1).permutation(len(y_all))\n",
-      "idx_train = idx_all[:int(.8 * len(y_all))]\n",
-      "idx_test = idx_all[int(.8 *  len(y_all)):]\n",
-      "\n",
-      "# TRAIN AND TEST DATA\n",
-      "X_train = X_all[idx_train]\n",
-      "y_train = y_all[idx_train]\n",
-      "X_test = X_all[idx_test]\n",
-      "y_test = y_all[idx_test]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "estimator = hpsklearn.HyperoptEstimator(\n",
-      "    preprocessing=hpsklearn.components.any_preprocessing('pp'),\n",
-      "    classifier=hpsklearn.components.any_classifier('clf'),\n",
-      "    algo=hyperopt.tpe.suggest,\n",
-      "    trial_timeout=15.0, # seconds\n",
-      "    max_evals=15,\n",
-      "    )"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Demo version of estimator.fit()\n",
-      "fit_iterator = estimator.fit_iter(X_train,y_train)\n",
-      "fit_iterator.next()\n",
-      "plot_helper = hpsklearn.demo_support.PlotHelper(estimator,\n",
-      "                                                mintodate_ylim=(-.01, .05))\n",
-      "while len(estimator.trials.trials) < estimator.max_evals:\n",
-      "    fit_iterator.send(1) # -- try one more model\n",
-      "    plot_helper.post_iter()\n",
-      "plot_helper.post_loop()\n",
-      "\n",
-      "# -- Model selection was done on a subset of the training data.\n",
-      "# -- Now that we've picked a model, train on all training data.\n",
-      "estimator.retrain_best_model_on_full_data(X_train, y_train)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEPCAYAAABRHfM8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XlcU1faB/BfICiy1B0RUFFBFoGIsqgVxSqyqGittrgX\nlVo6lrrUV23nnWK1Vmttx2VqrW2x7TtVq7aCiowVpa64gUvFBZmgLIoLArIJCef9gyFjICE36w3h\n+X4++chN7j33CT7hybn3nnMFjDEGQgghRAUzvgMghBDSMlDBIIQQwgkVDEIIIZxQwSCEEMIJFQxC\nCCGcUMEghBDCCa8FIyUlBe7u7nB1dcW6deuavP748WOEhYVhwIAB8PLywo4dOwwfJCFKqMpfAIiL\ni4OrqytEIhEyMzNlzzs7O8PHxwe+vr4ICAgwVMiEaIfxRCKRsL59+zKxWMxqamqYSCRiWVlZcut8\n9NFHbPny5Ywxxh49esQ6derEamtr+QiXEDlc8vfQoUMsPDycMcZYeno6CwwMlL3m7OzMnjx5YtCY\nCdEWbz2M8+fPw8XFBc7OzrCwsEBUVBQSExPl1unevTvKysoAAGVlZejcuTOEQiEf4RIih0v+JiUl\nYfbs2QCAwMBAlJSUoKioSPY6ozGzpIXhrWAUFBSgR48esmUnJycUFBTIrRMTE4Pr16/DwcEBIpEI\nGzduNHSYhCjEJX+bW0cgEGD06NHw8/PD9u3bDRM0IVri7eu6QCBQuc6aNWswYMAApKWlIScnByEh\nIbhy5QpsbW0NECEhynHJX0B5L+LUqVNwcHDAo0ePEBISAnd3dwQFBekyREJ0jreC4ejoiLy8PNly\nXl4enJyc5NY5c+YMPvzwQwBA37590bt3b9y6dQt+fn5y67m4uCAnJ0f/QZNWqW/fvrhz547cc1zy\nt/E6+fn5cHR0BAA4ODgAALp27YpXX30V58+fb1IwKK+JPinKa5X4OnlSW1vL+vTpw8RiMXv+/LnC\nk4aLFi1i8fHxjDHGHjx4wBwdHRWeKNT2bXz00UdabU9tmHYbivKLS/6+eNL77NmzspPeFRUVrKys\njDHGWHl5ORs6dCj717/+xWm/uqCL34mh2m1Jsba0djXJL956GEKhEFu2bEFoaCikUinmzp0LDw8P\nbNu2DQAwf/58fPDBB4iOjoZIJEJdXR0+++wzdOrUia+QCZHhkr8RERFITk6Gi4sLrK2tkZCQAAB4\n8OABJk2aBACQSCSYPn06xowZw9t7IYQrXi85Cg8PR3h4uNxz8+fPl/3cpUsXHDhwwNBhEcKJqvwF\ngC1btjTZrk+fPrh8+bJeYyNEH2ikN4Dg4GBqg9poNfT1O9FHuy0p1pbYrroE/zmW1aIJBAK6pp3o\nDV/5RXlN9EmT/KIeBiGEEE6oYBBCCOGECgYhhBBOqGAQQgjhhAoGIYQQTqhgEEII4YQKBiGEEE6o\nYBBCCOGECgYhhBBOqGAQQgjhhAoGIYQQTqhgEEII4YQKBiGEEE6oYBBCCOGE14KRkpICd3d3uLq6\nYt26dU1e//zzz+Hr6wtfX194e3tDKBSipKSEh0gJIYTwdj8MqVQKNzc3HD16FI6OjvD398fOnTvh\n4eGhcP2DBw/i73//O44ePdrkNbpvANEnuh8GMUUt6n4Y58+fh4uLC5ydnWFhYYGoqCgkJiYqXf/n\nn3/G1KlTDRghIYSQF/FWMAoKCtCjRw/ZspOTEwoKChSuW1lZiX/961947bXXDBUeIYSQRoR87Vgg\nEHBe98CBAxg2bBg6dOigdJ34+HjZz8HBwUZzD1zS8qSlpSEtLY3vMAgxOrwVDEdHR+Tl5cmW8/Ly\n4OTkpHDdXbt2qTwc9WLBIEQbjb9wrFy5kr9gCDEivJ30lkgkcHNzQ2pqKhwcHBAQEKDwpHdpaSn6\n9OmD/Px8tGvXTmFbdHKQ6BOd9CamSJP84q2HIRQKsWXLFoSGhkIqlWLu3Lnw8PDAtm3bAADz588H\nAOzfvx+hoaFKiwUhhBDD4K2HoUv0TYzoE/UwiClqUT2MlqS6uhpCoRBCIf26WqIbN24gNzcXZmZm\n6NWrF9zd3fkOiZAWif4CNqOiogKTJ8/C778fhEBghkWLlmDdulVqXeFF+CEWi/Hll18iOTkZjo6O\ncHBwAGMM9+/fR35+PsaNG4dFixbB2dmZ71C19ve/A599xn39b78FIiL0Fw8xXXRIqhlz5vwFO3c+\nQXX1DwBKYW09Bl99tQSzZs3U+b6Ibr3++uuIiYlBcHAwLCws5F6rra3F8ePH8e233+KXX35R2Zax\nH5J69qz+wcXHHwOursCSJVoGR1q8FjXSuyVISzuN6uqlANoCsENFRQyOHj3Fd1iEg19++QUhISFN\nigUAWFhYYMyYMZyKRXNUzYUGAHFxcXB1dYVIJEJmZqbca1KpFL6+vhg/frxWcdjaAg4O3B49egDF\nxVrtjrRiVDCa4eDQHQLB+f8sMbRtex7Ozg68xkTUU1FRgVWrViEmJgYAkJ2djYMHD2rdrlQqxYIF\nC5CSkoKsrCzs3LkTN27ckFsnOTkZd+7cQXZ2Nr755hvExsbKvb5x40Z4enoa9BBnp05UMIjmqGA0\n4+uv1+Ollz6Gjc1k2NiMQs+eV7BkyUK+wyJqiI6ORps2bXDmzBkAgIODAz788EOt2+UyF1pSUhJm\nz54NAAgMDERJSQmKiooAAPn5+UhOTsa8efMMerirY0cqGERzVDCa4eXlhZs3M/H1169ix46/4PLl\nM2jfvj3fYRE15OTkYNmyZWjTpg0AwNraWiftcpkLrbl1Fi1ahPXr18PMzLAfQephEG3QVVIq2Nvb\nY/r06XyHQTTUtm1bVFVVyZZzcnLQtm1brdvlehipce+BMYaDBw/Czs4Ovr6+Bp+zigoG0QYVDGLS\n4uPjERYWhvz8fEybNg2nT5/Gjh07tG6Xy1xojdfJz8+Ho6Mj9u3bh6SkJCQnJ6O6uhplZWWYNWsW\nfvzxR4XxN9DFpJpUMFovXUyqSZfVEpP3+PFjpKenA6g/l9C1a1e1tleUX1zmQktOTsaWLVuQnJyM\n9PR0LFy4UBZHgz/++AOff/45Dhw4wGm/2iopAXr1AkpLddosaYFopDchjYwaNQqpqakYN25ck+e0\nwWUutIiICCQnJ8PFxQXW1tZISEhQ2JYhr5J66SWgogKorQUUXHFMSLOoh0FMUlVVFSorKzFy5Ei5\nbnhZWRnCwsJw8+ZNzm0Z+8A9dXXpAty4AajZ0SImhnoYhPzHtm3bsHHjRhQWFmLQoEGy521tbbFg\nwQIeI+Nfw3kMKhhEXdTDICZt06ZNiIuL06oNU+thDB4MfPklMGSIzpsmLQj1MAhpJC4uDn/++Sey\nsrJQXV0te37WrFk8RsUvulKKaIoKBjFp8fHx+OOPP3D9+nWMHTsWhw8fxrBhw6hgUMEgGuB1pDeX\nydvS0tLg6+sLLy8vra9BJ63P3r17cfToUXTv3h0JCQm4cuUKSkpK+A6LV1QwiKZ462E0TN529OhR\nODo6wt/fH5GRkXLXsZeUlOAvf/kL/vWvf8HJyQmPHz/mK1zSQrVr1w7m5uYQCoUoLS2FnZ2d3GC6\n1ogKBtEUbz0MLpO3/fzzz3jttddkI2i7dOnCR6ikBfP398fTp08RExMDPz8/+Pr6YujQoXyHxatO\nnYCnT/mOgrREvPUwFE3Mdu7cObl1srOzUVtbi5EjR+LZs2d47733MHMm3byIcPfVV18BAN5++22E\nhoairKwMIpGI56j4RT0MoineCgaX0a21tbXIyMhAamoqKisrMWTIEAwePBiurq5N1tX1nDukZbt0\n6ZLSHMvIyMDAgQOVbquLOXeMGRUMoineCgaXydt69OiBLl26oF27dmjXrh2GDx+OK1euqCwYhCxZ\nsgQCgQBVVVW4dOkSfHx8AABXr16Fn58fzp49q3Tbxl84Vq5cqe9wDYoKBtEUb+cw/Pz8kJ2djdzc\nXNTU1GD37t2IjIyUW2fChAk4deoUpFIpKisrce7cOXh6evIUMWlJ0tLScPz4cTg4OCAjIwOXLl3C\npUuXkJmZCQeH1n3XRCoYRFO89TC4TN7m7u6OsLAw+Pj4wMzMDDExMVQwiFpu3rwJb29v2bKXl1eT\nW6m2NlQwiKZoahBi0qKiomBjY4MZM2aAMYaff/4Z5eXl2LlzJ+c2TG1qEIkEsLQEamoAA9/wjxgR\nTfKLCgYxaVVVVdi6dStOnjwJABg+fDhiY2NhaWnJuQ1TKxgA0L49cPcu0KGDXponLQAVDEKacenS\nJbmZa7kyxYLRuzeQmgr06aOX5kkLoEl+UYeUtBoxMTF8h2A06DwG0QQVDNJqUC/0v6hgEE1QwSCt\nxkcffcR3CEaDCgbRBE1vTkze5cuXZSe9r1y50uqnBgGoYBDNUA+DmLSNGzdixowZePToER4+fIgZ\nM2Zg06ZNfIfFOyoYRBN0lRQxad7e3khPT4e1tTUAoKKiAoMHD8a1a9c4t2GKV0lt2AAUFABffKGX\n5kkLQFdJEaKA2Quj08xopBoA6mEQzag8h1FRUYEvvvgC9+7dw/bt25GdnY1bt25h3LhxhoiPEK1E\nR0cjMDAQkyZNAmMM+/fvx5w5c/gOi3dUMIgmVB6Sev311zFo0CD8+OOPuH79OioqKjB06FBcuXLF\nUDGqRIekSHMuXbqEU6dOQSAQICgoCL6+vmptb4qHpE6eBFasAE6d0kvzpAXQJL9U9jBycnLwyy+/\nYNeuXQAgOxZMSEswc+ZM/PTTT3IjvBuea82oh0E0ofKAbtu2bVFVVSVbzsnJQdu2bfUaFCG68uef\nf8otSyQSXLp0iadojAcVDKIJlQUjPj4eYWFhyM/Px7Rp0/DKK69g3bp1hoiNEI2tWbMGtra2uHbt\nGmxtbWUPOzu7JvddaY06dqwvGHQkl6iD02W1jx8/Rnp6OgAgMDAQXbt21Xtg6qBzGESZ5cuXY+3a\ntVq1YYrnMADA2hp4+LD+X9L66GW22lGjRiE1NVXlc3yigkH0yVQLRo8ewJkz9f+S1ken4zCqqqrw\n5MkTPHr0CMXFxbJHbm4uCgoKtA4WAFJSUuDu7g5XV1eFh7nS0tLQvn17+Pr6wtfXF6tXr9bJfgnR\nBVX5CwBxcXFwdXWFSCRCZmYmAKC6uhqBgYEYMGAAPD09sWLFCkOGLUPnMYjamBJffvklc3Z2Zm3a\ntGHOzs6yh7e3N9u8ebOyzTiTSCSsb9++TCwWs5qaGiYSiVhWVpbcOsePH2fjx49X2VYzb4MQrSnK\nLy75e+jQIRYeHs4YYyw9PZ0FBgbKXquoqGCMMVZbW8sCAwPZyZMnOe1Xl4KDGTt2TK+7IEZMk/xS\n2sNYuHAhxGIx1q9fD7FYLHtcvXoVCxYs0LpQnT9/Hi4uLnB2doaFhQWioqKQmJioqKBpvS/Sup08\neRIJCQkAgEePHkEsFmvdJpf8TUpKwuzZswHUn/srKSlBUVERAMDKygoAUFNTA6lUik6dOmkdk7qo\nh0HUpXIcRlxcHP78809kZWWhurpa9vysWbO02nFBQQF6vHDw1MnJCefOnZNbRyAQ4MyZMxCJRHB0\ndMTnn38OT09PrfZLWpf4+HhcunQJt27dQnR0NGpqajBjxgycPn1aq3a55K+idfLz89GtWzdIpVIM\nGjQIOTk5iI2N5SWvqWAQdaksGPHx8fjjjz9w/fp1jB07FocPH8awYcO0LhgCgUDlOgMHDkReXh6s\nrKxw+PBhTJw4Ebdv31YaZ4Pg4GAEBwdrFR8xDb/99hsyMzNlA/ccHR3x7NmzZrdJS0tDWlpas+tw\nyV+gaQ+5YTtzc3NcvnwZpaWlCA0NRVpamsKc1WdeU8FoXbjktSoqC8bevXtx5coVDBw4EAkJCSgq\nKsL06dO12ilQ/8HNy8uTLefl5cHJyUluHVtbW9nP4eHheOedd1BcXKyw+/7iB4uQBm3btpWbcLCi\nokLlNo3/MK9cubLJOlzyt/E6+fn5cHR0lFunffv2GDt2LC5evKiyYOhaw1gM0jpwyWtVVA7ca9eu\nHczNzSEUClFaWgo7Ozu5D4Gm/Pz8kJ2djdzcXNTU1GD37t1NBlQVFRXJvqGdP38ejDFejvWSlmvK\nlCmYP38+SkpK8M0332DUqFGYN2+e1u1yyd/IyEj8+OOPAID09HR06NAB3bp1w+PHj1FSUgKg/mrE\n33//Xe35rXSBehhEXSp7GP7+/nj69CliYmLg5+cHa2trDB06VPsdC4XYsmULQkNDIZVKMXfuXHh4\neGDbtm0AgPnz52Pv3r3YunUrhEIhrKysZPNZEcLV0qVLceTIEdja2uL27dtYtWoVQkJCtG6XS/5G\nREQgOTkZLi4usLa2lp14v3//PmbPno26ujrU1dVh5syZGDVqlNYxqYsKBlFXswP3GGPIy8tDz549\nAQBisRhlZWVGd4tLGrhHlFm2bFmTMRKKnmuOqQ7cO3YMWLUKOH5cb7sgRkwvN1CKiIiQ/dy7d2+j\nKxaENOfIkSNNnktOTuYhEuNDPQyirmYLhkAgwKBBg3D+/HlDxUOITmzduhXe3t64desWvL29ZQ9n\nZ2f4+PjwHZ5RoIJB1KVyLik3NzfcuXMHvXr1kt0LQyAQ4OrVqwYJkAs6JEUaKy0txdOnT7F8+XKs\nW7dOlh+2trbo3LmzWm2Z6iGp8nKgWzeAw4VjxATpZfLB3Nxchc87OzurtSN9ooJBVHn48KHcwNOG\n83JcmGrBYAxo2xYoKwMsLfW2G2Kk9HLHPWMqDISoKykpCUuWLEFhYSHs7Oxw9+5deHh44Pr163yH\nxjuBoP6w1NOnQPfufEdDWgKVJ70Jacn++te/4uzZs+jXrx/EYjFSU1MRGBjId1hGg85jEHVQwSAm\nzcLCAl26dEFdXR2kUilGjhyJixcv8h2W0aCCQdTR7CEpiUSCkJAQHKcLtUkL1bFjRzx79gxBQUGY\nPn067OzsYGNjw3dYRoMKBlFHsz0MoVAIMzMz2TQGhLQ0iYmJsLKywpdffomwsDC4uLjgwIEDfIdl\nNKhgEHWoPOltbW0Nb29vhISEyF1Wu2nTJr0HR4g2JBIJxo0bh+PHj8Pc3Bxvvvkm3yEZnYaT3oRw\nobJgTJo0CZMmTZJNy8wY4zy1MyF8erGH3KFDB77DMUrUwyDqUFkw3nzzTTx//lx2Hwp3d3dYWFjo\nPTBCdKGhhzxmzBjZXe6oh/xfnToBf/7JdxSkpVBZMNLS0jB79mz06tULAHDv3j388MMPGDFihN6D\nI8aHMYbKykpYWVm1iJ4m9ZCbRz0Mog6VBWPx4sU4cuQI3NzcAAC3b99GVFQUMjIy9B4cMS4XL17E\nuHGv4/HjQrRv3wX79+9EUFAQ32E1i85bNI8KBlGHynEYEolEViwAoF+/fpBIJHoNihifyspKjBkz\nAUVFn0EqrUJx8bcYO3YyiumvTYtGBYOoQ2XBGDRoEObNm4e0tDQcP34c8+bNg5+fn052npKSAnd3\nd7i6ujZ7f4ILFy5AKBTi119/1cl+ifpycnIgkbQHMBmAAEAYzMx648aNGzxHRrRBBYOoQ2XB+Prr\nr+Hh4YFNmzZh8+bN6N+/P7Zu3ar1jqVSKRYsWICUlBRkZWVh586dCv/4SKVSLFu2DGFhYTTBII/s\n7OxQU1MIoOA/zzxGTc2/0d2IJyGSSqV4//33+Q7DqNF9vYk6VI70FolEuHnzJpYsWaLTHZ8/fx4u\nLi6yyQ2joqKQmJgIDw8PufU2b96MyZMn48KFCzrdP1FPt27d8NFHf8Xq1YNhZhYMxk5hwYJY9OnT\nh+/QlDI3N8epU6foRHcz2revn+ZcIgGEKs9oktau2RQRCoVwc3PD3bt3ZVdJ6UpBQQF69OghW3Zy\ncsK5c+earJOYmIhjx47hwoUL9KHn2YoV72P06BG4fv06+vWL1cm93fVtwIABmDBhAqZMmSJ3We2k\nSZN4jsw4mJnVF42SEqBLF76jIcZO5XeK4uJi9O/fHwEBAXIjvZOSkrTaMZc//gsXLsTatWtl87bT\nISn++fv7w9/fn+8wOKuurkanTp1w7NgxueepYPxXw3kMKhhEFZUFY/Xq1U3+UOvim76joyPy8vJk\ny3l5eXBycpJb59KlS4iKigIAPH78GIcPH4aFhQUiIyObtBcfHy/7OTg4GMHBwVrHSFq+HTt2qL1N\nWloa0tLSdB6LsaIT34SrZu+4J5FI0L9/f9y6dUvnO264XDc1NRUODg4ICAjAzp07m5zDaBAdHY3x\n48cr/GZId9wjyuTl5SEuLg6nTp0CAAwfPhwbN25s8uWkOaZ6x70G4eHAu+8CERF63xUxIprkl8rZ\nat3d3XH37l2tAlPW9pYtWxAaGgpPT0+88cYb8PDwwLZt27Bt2zad74+0TtHR0YiMjERhYSEKCwsx\nfvx4REdH8x2WUaEeBuFK5T29g4KCkJmZqfNzGLpEPQyijEgkwpUrV1Q+1xxT72G8+y7g6grExel9\nV8SI6OWe3qtWrVK4I0Jags6dO+Onn37CtGnTwBjDrl270IXO7sqhHgbhSuXAveDgYDg7O0MikSA4\nOBgBAQHw9fU1RGyEaC0hIQG//PIL7O3t0b17d+zZswcJCQl8h2VUqGAQrlT2ML755hts374dxcXF\nyMnJQX5+PmJjY5GammqI+AjRmEQiwQcffEB32FOhUyeAxsUSLlT2MP7xj3/g1KlTeOmllwDUTz74\n8OFDvQdGiLaEQiHu3r2L58+f8x2KUaMeBuFKZcFo27Yt2rZtK1uWSCR0DoO0GL1798awYcOwatUq\nbNiwARs2bMAXX3yhk7a5TJ4ZFxcHV1dXiEQiZGZmAqi/1HfkyJHo378/vLy8eL+ZExUMwpXKQ1Ij\nRozAJ598gsrKSvz+++/46quvMH78eEPERojWXFxc0LdvX9TV1aG8vFxn7TZMnnn06FE4OjrC398f\nkZGRcuOIkpOTcefOHWRnZ+PcuXOIjY1Feno6LCws8OWXX2LAgAEoLy/HoEGDEBISonQMkr7Rfb0J\nVyoLxtq1a/Hdd9/B29sb27ZtQ0REBObNm2eI2AjRikQiwa1bt/Dzzz/rvG0uk2cmJSVh9uzZAIDA\nwECUlJSgqKgI9vb2sLe3BwDY2NjAw8MDhYWFvBYM6mEQLlQWDHNzc7z11lt46623DBEPITojFApx\n7949PH/+XO6wqi5wnTyz8Tr5+fno1q2b7Lnc3FxkZmYiMDBQp/Gpo2PH+h5GXV39ZISEKEMTGhOT\n1nAOIzIyUm622sWLF2vVLtfzeM3Nw1ZeXo7Jkydj48aNsLGxUbi9IeZIEwoBa2vg2bP6mWuJadLF\nHGlUMIhMeXk5Dh8+jNraWoSEhKBr1668xPHgwQOkpqbC0tIS4eHhsj/0mujbt69ezmFwmTyz8Tr5\n+flwdHQEANTW1uK1117DjBkzMHHiRKX7ebFg6FPDYSkqGKar8ReOlStXqt8IMwEm8jZ49fjxY+bs\n7MlsbEKYjc2rrGNHB3br1i2Dx3Ht2jXWvr09s7F5jdnYjGSuriJWUlKidbvl5eUab6sov2pra1mf\nPn2YWCxmz58/ZyKRiGVlZcmtc+jQIRYeHs4YY+zs2bMsMDCQMcZYXV0dmzlzJlu4cKHa+9WXgQMZ\nu3jRYLsjRkCT/FJ5xPLWrVuIiYlBSEgIRo4ciZEjR+KVV15RvzIRo7ZmzXoUFgahvPwIyst/RWnp\nEixYsNzgcbz99lKUlf0N5eV7UV6einv3RNiw4e8at3fmzBl4enrC3d0dAHDlyhW88847WsfJZfLM\niIgI9OnTBy4uLpg/fz6++uorAMDp06fxf//3fzh+/Dh8fX3h6+uLlJQUrWPSBp34JlyoPCQ1ZcoU\nxMbGYt68eTA3NwdAc0mZotzc+6ipGSFbrqsLQH7+HoPHUVh4H4wF/GdJgOfPA5Cbe1Xj9hYuXIiU\nlBRMmDABQP3Eg3/88YcOIgXCw8MRHh4u99z8+fPllrds2dJku2HDhqGurk4nMegK3dubcKGyYFhY\nWCA2NtYQsRAehYS8jJSUr1FZOQGAFSwtN2DUqGEGjyM4+GXcv78e1dU/ACiFtfV2jB6t3f3ke/bs\nKbcspJtXN0E9DMKFykNS48ePxz/+8Q/cv38fxcXFsgcxLfPnx2Du3BEQCh1hbt4BY8ZYYv36pjMV\n69vmzZ8hOLgW5uYvQSjsiXfeGYeZM2do3F7Pnj1x+vRpAEBNTQ0+//xz3sY7GDMqGIQLlffDcHZ2\nbnIISiAQ4N///rdeA1MH3Q9DdyQSCaRSqc7HLairuroaQqFQ697Ao0eP8N577+Ho0aNgjGHMmDHY\ntGkTOnfuzLkNU78fBgB8/jlw/z6wYYNBdkeMgCb5pbJg6FNKSgoWLlwIqVSKefPmYdmyZXKvJyYm\n4m9/+xvMzMxgZmaG9evXKzzhTgWD6FNrKBjffw+cPAnQzO+th14KRk1NDbZu3YoTJ05AIBBgxIgR\nePvtt2FhYaFVsFKpFG5ubnJz8TS+p3dFRYXsLn/Xrl3Dq6++ijt37jR9E1QwiB61hoKxf399sUhM\nNMjuiBHQ+T29ASA2NhYZGRn4y1/+gtjYWFy6dEknJ8FfnIvHwsJCNhfPixqKBVA/qIzulEaIftA5\nDMKFygPEFy5cwNWr/72scdSoUfDx8dF6x1zm4gGA/fv3Y8WKFbh//z6OHDmi9X4JIU1RwSBcqCwY\nQqEQd+7cgYuLCwAgJydHJ5clch3LMXHiREycOBEnT57EzJkzcevWLa33TVqP6upq7Nu3D7m5uZBI\nJADqc+9vf/sbz5EZFyoYhAuVf/kbTjT37t0bQP3smrq4JzKXuXheFBQUBIlEgidPnii8wsUQk7SR\nlmfChAno0KEDBg0aBEtLS07b6GKStpamYeAeYwCNyyXKcLpKqrq6Grdu3YJAIICbm5tOLrmUSCRw\nc3NDamoqHBwcEBAQ0OSkd05ODvr06QOBQICMjAxMmTIFOTk5Td8EnfQmSnh5eeHPP//Uqo3WcNIb\nAKysgEeP6meuJaZPk/xS2sNITU3FqFGjsG/fPrmGG65SmjRpkhahys/FI5VKMXfuXNlcPED9FAv7\n9u3Djz8fxPfAAAAgAElEQVT+CAsLC9jY2GDXrl1a7ZO0PkOHDsXVq1d1ct7N1DUclqKCQZRR2sP4\n6KOPsHLlSrz55psKzzfo4rCUrlAPgyjj4eGBO3fuoHfv3rKesUAgkLuQQ5XW0sPw8QF++gkQiQy2\nS8IjvYzD+Pe//40+ffqofI5PVDCIMrm5uQD+e5FFQ5403FqVi9ZSMIKDgfj4+n+J6dPLOIzJkyc3\neW7KlClq7YQQvjg7O6OkpARJSUk4cOAASktL1SoWrQldKUVUUXoO48aNG8jKykJJSQl+/fVXMMYg\nEAhQVlaG6upqQ8ZIiMY2btyI7du3Y9KkSWCMYcaMGYiJiUFcXBzfoRkdKhhEFaUF4/bt27JvZAcO\nHJA9b2tri+3btxskOEK09e233+LcuXOyWQOWL1+OwYMHU8FQgAoGUUVpwZgwYQImTJiAM2fOYOjQ\noYaMiRCdMjMzU/gzkUcFg6iicuCer68vtmzZgqysLFRVVclOHn7//fd6D84UMMbw9dfbsWvXQXTq\n9BJWr16B/v378x1WqxEdHY3AwEDZIan9+/djzpw5fIdllDp1AozorgXECKn8ujVz5kwUFRUhJSUF\nwcHByMvLg42NjSFiMwmffPIZ3n9/C06ceBOJib4YPHikUd1LxNQtXrwYCQkJ6NixIzp37owdO3Zg\n0aJFfIdllKiHQVRReVntgAEDcPnyZfj4+ODq1auora3FsGHDFE4UyBdjvqy2a1dnPH58EIAXAEAo\njEN8vD0+/PADfgMzcWVlZXjppZdkd4dsyI+GHnKnTp04t9VaLqtNTQU++QQ4dsxguyQ80ulI7wZt\n2rQBALRv3x7Xrl2Dvb09Hj16pFmEhBjI1KlTcejQIQwcOFDhwFOxWMxDVMaNehhEFZUFIyYmBsXF\nxVi9ejUiIyNRXl6OVasMf6/nluq992Lx6afTUFkZD4FADEvLXZg6NZ3vsEzeoUOHAPx34B5RjQoG\nUYXXW7TqijEfknrxpHfnzu2xevUKeHp68h1WqzFq1CikpqaqfK45reWQ1LNnQPfuQHm5wXZJeKTT\nqUE2vHA3+IaGX+zaL168WMMwdc+YCwbhR1VVFSorKzFy5Ei5qcrLysoQFhaGmzdvcm6rtRQMxoA2\nbeoLhg4mpCZGTqfnMJ49ewaBQIBbt27hwoULiIyMBGMMBw8eREBAgNbBEqJP27Ztw8aNG1FYWIhB\ngwbJnre1tcWCBQt4jMx4CQT1h6WePgXs7fmOhhgjlYekgoKCkJycDFtbWwD1hSQiIgInT540SIBc\nUA+DKLNp0yatR3W3lh4GAHh4APv2AXTU1PTp5Sqphw8fwsLCQrZsYWGBhw8fqh8dITyIi4vDn3/+\niaysLLk50GbNmsVjVMaLTnyT5qgsGLNmzUJAQIDcSNnZs2cbIjZCtBYfH48//vgD169fx9ixY3H4\n8GEMGzaMCoYSVDBIc1SO9P7www+RkJCADh06oFOnTtixYwc++EA3g85SUlLg7u4OV1dXrFu3rsnr\n//znPyESieDj44OXX35ZrZveEAIAe/fuxdGjR9G9e3ckJCTgypUrKCkp0UnbqvIXqO/huLq6QiQS\nITMzU/b8nDlz0K1bN3h7e+skFl2hgkGaxZQoLS1ljDH25MkT9uTJE/b48WP2+PFj2bK2JBIJ69u3\nLxOLxaympoaJRCKWlZUlt86ZM2dYSUkJY4yxw4cPs8DAQIVtNfM2SCvn5+fHGGNs4MCBrKSkhNXV\n1bF+/fqp1Yai/OKSv4cOHWLh4eGMMcbS09Pl8vfEiRMsIyODeXl5qbVffVu4kLENGwy+W8IDTfJL\n6SEpfY+UPX/+PFxcXGQ3s4mKikJiYiI8PDxk6wwZMkT2c2BgIPLz87XaJ2l9/P398fTpU8TExMDP\nzw/W1tY6mX2ZS/4mJSXJDt8GBgaipKQEDx48gL29PYKCgoxyUCH1MEhzlBYMfY+ULSgoQI8ePWTL\nTk5Ozc5P9d133yEiIkIvsRDT9dVXXwEA3n77bYSGhqKsrAwiHdy0mkv+KlqnoKAA9kZ8zWqnTsD1\n63xHQYyV0oKRkZHR7IYDBw7UaseKei3KHD9+HN9//z1Onz6tdJ34+HjZz8HBwQimGxO3apcuXVKa\nYxkZGc3mb1pamtxgP0W45i9rdNmiOnkPGD6vqYdhurjktSpKC8bixYubTe7jx49rtWNHR0fk5eXJ\nlvPy8uDk5NRkvatXryImJgYpKSno2LGj0vZe/GARsmTJEggEAlRVVeHSpUvw8fEBUJ9Pfn5+OHv2\nrNJtG/9hXrlyZZN1uORv43Xy8/Ph6Oio1vswdF43DNwjpodLXquk+1Mp3NTW1rI+ffowsVjMnj9/\nrvCk4d27d1nfvn3Z2bNnm22Lx7dBjNyrr77Krl69Klu+du0amzRpklptKMovLvn74knvs2fPNrlo\nQywWG91J7/PnGfvPdQLExGmSXyrHYQDAtWvXcOPGDZ0OfBIKhdiyZQtCQ0MhlUoxd+5ceHh4YNu2\nbQCA+fPn4+OPP8bTp08RGxsLoH7Q4Pnz57XaL2ldbt68KXfpqpeXF27cuKF1u1zyNyIiAsnJyXBx\ncYG1tTUSEhJk20+dOhV//PEHnjx5gh49euDjjz9GdHS01nFpiw5JkeaonBpE2cCnvXv3GipGlWhq\nEKJMVFQUbGxsMGPGDDDG8PPPP6O8vBw7d+7k3EZrmhrk6VOgTx86LNUa6HS22gZeXl64cuUKBg4c\niCtXrqCoqAjTp0/H0aNHtQpWl6hgEGWqqqqwdetW2dxnw4cPR2xsLCwtLTm30ZoKRl1d/Yy1z58D\n5uYG3TUxML3MJdWuXTuYm5tDKBSitLQUdnZ2cifyCDFm7dq1w+LFi41qOn5jZmYGtG8PlJQAnTvz\nHQ0xNioLhp+fn14GPhGiT1OmTMGePXsUTr0hEAhomplmNJzHoIJBGlN6SOqdd97BtGnTMGzYMNlz\nYrFYZwOfdIkOSZHGCgsL4eDgoHTgacMIbS5a0yEpAAgIADZvBgIDDb5rYkA6PSTVr18/LF26FIWF\nhXjjjTcwdepU+Pr6ah0kIYbg4OAAQL3CQOrRlVJEGZUnvXNzc7Fr1y7s3r0blZWVmDZtGqZOnYp+\n/foZKkaVqIdBGrOxsVE68FQgEKCsrIxzW62thzFtGjB2LDB9usF3TQxIL1dJvSgzMxPR0dG4du0a\npFKp2gHqCxUMok+trWAsWAC4uQHvvmvwXRMD0iS/VN4PQyKRICkpCdOmTUNYWBjc3d3x66+/ahwk\nIXx4+PAh7t27J3sQ5eiQFFFG6TmMI0eOYNeuXTh06BACAgIwdepUfPPNN7CxsTFkfIRoJSkpCUuW\nLEFhYSHs7Oxw9+5deHh44DpNyapUp06AlncvICZKaQ9j7dq1GDJkCG7cuIEDBw5g2rRpVCxIi/PX\nv/4VZ8+eRb9+/SAWi5GamopAuvynWdTDIMoo7WEcO3bMkHEQohcWFhbo0qUL6urqIJVKMXLkSLz3\n3nt8h2XUqGAQZThNPkhIS9WxY0c8e/YMQUFBmD59Ouzs7KinrAIVDKKMypPehLREe/bsQXV1NRIT\nE2FlZYUvv/wSYWFhcHFxwYEDB/gOz6hRwSDKqHVZrbGiy2pJYxMnTsTp06cRFhaGqVOnIjQ0FOYa\nzqbX2i6rffgQ6N8fePTI4LsmBqT3cRjGigoGUaS0tBS//fYbdu3ahcuXL2PixImYOnUqRowYoVY7\nra1g1NYC7doBNTX1kxES00QFgxAlHj9+jH379uEf//gHiouLkZ+fz3nb1lYwAOCll4C8vPqZa4lp\n0svAPX1KSUmBu7s7XF1dsW7duiav37x5E0OGDIGlpSU2bNjAQ4TEFDx9+hS//vordu/ejeLiYkyZ\nMoXvkIwe3dubKMLbVVJSqRQLFizA0aNH4ejoCH9/f0RGRsLDw0O2TufOnbF582bs37+frzBJC/Xs\n2TPZ4aiMjAxERkbif//3fxEcHKx0jinyXw0nvmnuRvIi3grG+fPn4eLiIptNNCoqComJiXIFo2vX\nrujatSsOHTrEU5SkpXJ2dkZYWBjeeecdjBkzBm3atOE7pBaFrpQiivBWMAoKCtCjRw/ZspOTE86d\nO8dXOMTE5Ofno127dnyH0WJRwSCK8FYwdH1YID4+XvZzcHAwgoODddo+aVkmT56MN998E2PHjoWV\nlZXcaxUVFTh48CB++OEHJCcnN9k2LS0NaWlpBorUOFHBIIrwVjAcHR3l7g2el5cHJycnjdt7sWC0\nRs+fP0dycjIqKioQHBys1e/SFCQkJGDLli346KOPYG5uju7du4MxhgcPHkAikeCNN97ADz/8oHDb\nxl84Vq5caaCojQcVDKIIbwXDz88P2dnZyM3NhYODA3bv3o2dO3cqXJcumW1eZWUlhgwZjX//2xyA\nA4DFOHbsEPz9/fkOjTd2dnb4+OOP8fHHH+PBgwe4e/cuAKBXr16wt7fnOTrj16kT8OAB31EQY8Nb\nwRAKhdiyZQtCQ0MhlUoxd+5ceHh4YNu2bQCA+fPn48GDB/D390dZWRnMzMywceNGZGVl0VxAjWzb\ntg23b9ujunofAAGAf2Lu3IW4evU036EZBXt7eyoSaurYEcjK4jsKYmx4nXwwPDwc4eHhcs/Nnz9f\n9rO9vb3cYSuiWF7efVRX+6O+WABAAB48+F8+QzIa+/btw/Lly1FUVCTrqap7i9bWiA5JEUVo4L8J\nGDHiZVhZ7QCQD6AWbdqsw7BhL/MclXH4n//5HyQlJaGsrAzPnj3Ds2fPqFhwQAWDKEIFwwRMmDAB\nK1bMgYVFP5ib22DIkPv4/vvNfIdlFOzt7eXG9hBuqGAQRWguKRMilUpRW1sLS0tLvkMxGu+99x4e\nPHiAiRMnygbvCQQCTJo0iXMbrXEuqYICwN8fKCzkZffEAFrcXFJEt8zNzalYNFJaWop27drhyJEj\nOHjwIA4ePKiz+2GomgsNAOLi4uDq6gqRSITMzEy1tuVTQw+DvocROcwEmMjbIEZKUX5JJBLWt29f\nJhaLWU1NDROJRCwrK0tunUOHDrHw8HDGGGPp6eksMDCQ87bK9mtIlpaMVVTwGgLRI03yi27RSkzS\nunXrsGzZMrz77rtNXhMIBNi0aZNW7XOZCy0pKQmzZ88GAAQGBqKkpAQPHjyAWCxWua0xaOhlNBoo\nT1qxVl8wGGOorKyEtbU136GYjJqaGggEAlhYWPAWg6enJwBg0KBBTV7TxbQ0XOZCU7ROQUEBCgsL\nW8Q8ag0Fo5VPGkBe0KoLRmpqKiZPnoFnz56iW7ceSE7eC5FIxHdYLVZtbS1mz34bv/zyfxAIBJg5\ncw62b9+s8a1RtTF+/HgAwJtvvqmX9rkWHdaCTwJ07w688gpAE/2SBq22YBQVFWHChChUVPwCIBiF\nhT9j9OhIFBRk01TYGvr447VITMyDVPoEQB12745Ev35fYvny93mL6cKFC1izZg1yc3MhkUgA1P+x\nv3r1qlbtcpkLrfE6+fn5cHJyQm1tLed51PicVHP/fqCkxGC7I3p25kwazp5Nky1/8YUGjej8TAoP\nNHkbv//+O2vfPpjVXwdS/7C2dmbZ2dl6iLB1CAwcw4BDL/xO97CRIyfwGpOrqytLTExkOTk5TCwW\nyx7qUJRftbW1rE+fPkwsFrPnz5+rPOl99uxZ2UlvLtsq2y8huqJJfrXaHkb37t1RW3sbQAmADgDu\nQiJ5gq5du/IcWcvVs2d3XLx4DlJpBABAKDyPXr268xpT165dERkZqfN2ucyFFhERgeTkZLi4uMDa\n2hoJCQnNbkuIsWvVA/fi4v4H33//K4AhYOwY1qz5AO+99xfdB9hK3Lt3D/7+w1FZ6QNAChubm8jI\nOIXu3fkrGkeOHMHu3bsxevRoGrhHyAs0ya9WXTAA4OTJk8jJyYGPjw8GDhyo48han+LiYhw5cgQC\ngQBhYWFo3749r/FMnz4dt27dQv/+/WFm9t9xqg3f9rmggkFMERUMQhpxc3PDzZs3tbqUlgoGMUU0\nNQghjQwdOhRZdGMHQnSCehjEpLm7uyMnJwe9e/dG27ZtAah/WS31MIgp0iS/eL1KKiUlBQsXLoRU\nKsW8efOwbNmyJuvExcXh8OHDsLKywo4dO+Dr68tDpKSlSklJ4TsEQkwGb4ekpFIpFixYgJSUFGRl\nZWHnzp24ceOG3DrJycm4c+cOsrOz8c033yA2NpanaJUrKCjAzJlvIShoHFauXIPa2lq127hz5w5e\nf/1NDB8+Hl98sQl1dXVyr0ulUqxbtwFBQeMQFTUHubm5au+jpqYGH364EsOGjcWbb8aiqKhI7TZ0\nobi4GG+9FYdhw8bi/fc/QFVVldptqPqdM8awdes3GDEiEosW/RUVFRVwdnaWexBCNKD5sA/tnDlz\nhoWGhsqWP/30U/bpp5/KrTN//ny2a9cu2bKbmxt78OBBk7b4ehslJSXM3r4PEwqXM2A/s7IazaZO\nnaNWGwUFBaxDh+7MzOwTBvzGrKz82fvvfyC3TmzsImZl9TID9jNz83jWubMTe/jwoVr7mTBhKmvX\nLpwBiUwoXMx69HBj5eXlarWhrerqatavny9r0yaWAYnM0vI1NnLkWFZXV8e5DS6/81Wr1jIrK28G\n7GMCwefMxqYry8nJ0ThuvvKLx48naQU0yS/eMnLPnj1s3rx5suWffvqJLViwQG6dcePGsdOnT8uW\nR40axS5evNikLb4+WHv27GG2tmEvjGx+xszN27KqqirObWzevJlZWs5+oY17zMqqo+z1uro6ZmHR\njgEPZetYWb3Ovv32W877KCkpYUKhFQMqZW3Y2o5gBw8eVOv9auvEiRPM1taXAXX/iaOGWVp2Zffu\n3ePcBpffeZcuvRhwTbaOUPguW736E43jpoJBTJEm+cXbOQxNJ29Tth2fc+4Q05KWloa0tDS+wyDE\n+Oi+bnFz9uxZuUNSa9asYWvXrpVbZ/78+Wznzp2y5dZ6SOqddxoOSf2mg0NS+5mFxWLWs6c7HZLi\niK/84vHjSVoBTfKLt4zUZvK2xvj8YBUUFLAZM2LYsGFjWXz8J6y2tlbtNrKzs9mUKbNZUNA4tmHD\nRiaVSuVel0gkbO3az9mwYWPZG29Eqz15HmOMPX/+nH3wQTx7+eUINnv22woLryE8efKExcS8y15+\nOYK9//4HrLKyUu02VP3O6+rq2FdfbWPDh49nr746g12/fl2rmKlgEFOkSX7xOg7j8OHDsstq586d\nixUrVshN3gZAdiVVw+RtiqbvoOvViT7ROAxiimhqEEL0gAoGMUU0NQghhBC9oYJBCCGEEyoYhBBC\nOKGCQQghhBMqGIQQQjihgkEIIYQTKhiEEEI4oYJBCCGEEyoYhBBCOKGCQQghhBMqGIQQQjihgkEI\nIYQTKhiEEEI4oYJBCCGEEyoYhBBCOOGlYBQXFyMkJAT9+vXDmDFjUFJSonC9OXPmoFu3bvD29jZw\nhIQoxzV/U1JS4O7uDldXV6xbt072/J49e9C/f3+Ym5sjIyPDUGETojVeCsbatWsREhKC27dvY9So\nUVi7dq3C9aKjo5GSkqL3eNLS0qgNaoMzLvkrlUpld4vMysrCzp07cePGDQCAt7c3fvvtNwwfPlzn\nsXGhj9+JvtptSbG2xHbVxUvBSEpKwuzZswEAs2fPxv79+xWuFxQUhI4dO+o9HmP5w0RtGGcbjXHJ\n3/Pnz8PFxQXOzs6wsLBAVFQUEhMTAQDu7u7o16+fzuPiqiX9UWtJsbbEdtXFS8EoKipCt27dAADd\nunVDUVERH2EQohEu+VtQUIAePXrIlp2cnFBQUGCwGAnRB6G+Gg4JCcGDBw+aPP/JJ5/ILQsEAggE\nAn2FQYhGGudvw3k0rvlLOU1MEuOBm5sbu3//PmOMscLCQubm5qZ0XbFYzLy8vJptr2/fvgwAPeih\nl0ffvn3Vzt+zZ8+y0NBQ2fKaNWvY2rVr5dYJDg5mly5dorymBy+PxnnNhd56GM2JjIzEDz/8gGXL\nluGHH37AxIkTtWrvzp07OoqMENW45K+fnx+ys7ORm5sLBwcH7N69Gzt37myyHmNM6X4or4nRUbvE\n6MCTJ0/YqFGjmKurKwsJCWFPnz5ljDFWUFDAIiIiZOtFRUWx7t27szZt2jAnJyf2/fff8xEuIXK4\n5m9ycjLr168f69u3L1uzZo3s+V9//ZU5OTkxS0tL1q1bNxYWFmbw90CIJgSMNfMVhxBCCPkPkxjp\nvXTpUnh4eEAkEmHSpEkoLS3lvK2ywVVc5eXlYeTIkejfvz+8vLywadMmtdtoIJVK4evri/Hjx2u0\nfUlJCSZPngwPDw94enoiPT1d7TY+/fRT9O/fH97e3pg2bRqeP3+uchtFAyy5Dm5rrg11/l+bG+S5\nYcMGmJmZobi4WO0YAGDz5s3w8PCAl5cXli1b1mwbuqJtXiqiy1xtTNvcVUQX+ayIJjnemC5ynmu7\n2vx9a67dBlw/HwD4OSSla0eOHGFSqZQxxtiyZcvYsmXLOG0nkUhY3759mVgsZjU1NUwkErGsrCy1\n9n3//n2WmZnJGGPs2bNnrF+/fmq30WDDhg1s2rRpbPz48RptP2vWLPbdd98xxhirra1lJSUlam0v\nFotZ7969WXV1NWOMsddff53t2LFD5XYnTpxgGRkZchcnLF26lK1bt44xxtjatWtV/p8oakOd/1dF\n2zPG2L1791hoaChzdnZmT548UTuGY8eOsdGjR7OamhrGGGMPHz5stg1d0EVeKqLLXG1M29xVRNt8\nVkTTHG9MFznPtV1N/76papcx9T4fjDFmEj2MkJAQmJnVv5XAwEDk5+dz2q65wVVc2dvbY8CAAQAA\nGxsbeHh4oLCwUL03ACA/Px/JycmYN29esydClSktLcXJkycxZ84cAIBQKET79u3VauOll16ChYUF\nKisrIZFIUFlZCUdHR5XbKRpgyXVwZnNtqPP/qmyQ5+LFi/HZZ5+pfA/K2ti6dStWrFgBCwsLAEDX\nrl05taUNXeSlIrrK1ca0zV1FdJHPimia443pIue5tqvp3zdV7QLqfT4AEzkk9aLvv/8eERERnNbV\n9eCq3NxcZGZmIjAwUO1tFy1ahPXr18sSQ11isRhdu3ZFdHQ0Bg4ciJiYGFRWVqrVRqdOnbBkyRL0\n7NkTDg4O6NChA0aPHq1RPLoenKnO/2uDxMREODk5wcfHR+P9Zmdn48SJExg8eDCCg4Nx8eJFjdvi\nyhCD/rTJ1ca0zV1FdJHPiugyxxszxIBkTT4Hymjy+WgxBSMkJATe3t5NHgcOHJCt88knn6BNmzaY\nNm0apzZ1ObiqvLwckydPxsaNG2FjY6PWtgcPHoSdnR18fX01/oYmkUiQkZGBd955BxkZGbC2tlY6\nR5cyOTk5+Pvf/47c3FwUFhaivLwc//znPzWK50XaDs5U9/8VACorK7FmzRqsXLlS9pwmv1uJRIKn\nT58iPT0d69evx+uvv652G+rS96A/bXK1MV3kriK6yGdF9JXjjeljQLImnwNlNP18tJiC8fvvv+Pa\ntWtNHg0n2Xbs2IHk5GS1/vMdHR2Rl5cnW87Ly4OTk5PasdXW1uK1117DjBkzNBpTcubMGSQlJaF3\n796YOnUqjh07hlmzZqnVhpOTE5ycnODv7w8AmDx5stozoV68eBFDhw5F586dIRQKMWnSJJw5c0at\nNhp069ZNNlL6/v37sLOz06gdTf5fgfo/DLm5uRCJROjduzfy8/MxaNAgPHz4UK12nJycMGnSJACA\nv78/zMzM8OTJE7XaUJeu8lIRbXO1MV3kriK6yGdFdJnjjekq5xXR9HOgjKafjxZTMJqTkpKC9evX\nIzExEZaWlpy3e3FwVU1NDXbv3o3IyEi19s0Yw9y5c+Hp6YmFCxeqGzoAYM2aNcjLy4NYLMauXbvw\nyiuv4Mcff1SrDXt7e/To0QO3b98GABw9ehT9+/dXqw13d3ekp6ejqqoKjDEcPXoUnp6earXRoGFw\nGwCNB2dq+v8K1E/lUVRUBLFYDLFYDCcnJ2RkZKj9IZ44cSKOHTsGALh9+zZqamrQuXNntdpQly7y\nUhFd5GpjushdRXSRz4roMscb00XOK6LN50AZjT8fap9uN0IuLi6sZ8+ebMCAAWzAgAEsNjaW87bK\nBldxdfLkSSYQCJhIJJLt//Dhw2q30yAtLU3jK00uX77M/Pz8mI+PD3v11Vc1uqpk3bp1zNPTk3l5\nebFZs2bJrg5qTsMASwsLC9kAS2WD27i28d1336n1/6pqkGfv3r1VXgWiqI2amho2Y8YM5uXlxQYO\nHMiOHz+u8vehC9rmpSK6ztXGtMldRXSRz4pokuON6SLnubSr7udAVbvafD4Yo4F7hBBCODKJQ1KE\nEEL0jwoGIYQQTqhgEEII4YQKBiGEEE6oYBBCCOGECgYhhBBOqGAYuYapG+7evavwjm3aWLNmjdzy\nyy+/rNP2CWkO5XbLQwXDyDXMRyMWi/Hzzz+rta1EImn29U8//VRu+fTp0+oFR4gWKLdbHioYLcTy\n5ctx8uRJ+Pr6YuPGjairq8PSpUsREBAAkUiEb775BgCQlpaGoKAgTJgwAV5eXgDqp7fw8/ODl5cX\ntm/fLmuvqqoKvr6+mDlzJoD/fuNjjGHp0qXw9vaGj48PfvnlF1nbwcHBmDJlCjw8PDBjxgxD/xqI\nCaLcbkHUHmNODMrGxoYxVj/twrhx42TPb9u2ja1evZoxxlh1dTXz8/NjYrGYHT9+nFlbW7Pc3FzZ\nusXFxYwxxiorK5mXl5dsuaHtxvvau3cvCwkJYXV1dayoqIj17NmT3b9/nx0/fpy1b9+eFRQUsLq6\nOjZkyBB26tQp/b15YtIot1se6mG0EKzRDC5HjhzBjz/+CF9fXwwePBjFxcW4c+cOACAgIAC9evWS\nrbtx40YMGDAAQ4YMQV5eHrKzs5vd16lTpzBt2jQIBALY2dlhxIgRuHDhAgQCAQICAuDg4ACBQIAB\nA1GUNO8AAAFgSURBVAYgNzdX5++VtC6U2y2HkO8AiOa2bNmCkJAQuefS0tJgbW0tt5yamor09HRY\nWlpi5MiRqK6ubrZdgUDQ5EPccLy5bdu2sufMzc1VHksmRBOU28aJehgthK2tLZ49eyZbDg0NxVdf\nfSVL6tu3byu8I1lZWRk6duwIS0tL3Lx5E+np6bLXLCwsFH4ogoKCsHv3btTV1eHRo0c4ceIEAgIC\ndHqDHEIaUG63HNTDMHIN335EIhHMzc0xYMAAREdHIy4uDrm5uRg4cCAYY7Czs8Nvv/3W5E5fYWFh\n+Prrr+Hp6Qk3NzcMGTJE9tpbb70FHx8fDBo0CD/99JNsu1dffRVnz56FSCSCQCDA+vXrYWdnhxs3\nbjS5i5i+7w5HTBfldstD05sTQgjhhA5JEUII4YQKBiGEEE6oYBBCCOGECgYhhBBOqGAQQgjhhAoG\nIYQQTqhgEEII4YQKBiGEEE7+H5u6BE2js1hUAAAAAElFTkSuQmCC\n"
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print 'Best preprocessing pipeline:'\n",
-      "for pp in estimator._best_preprocs:\n",
-      "    print pp\n",
-      "print\n",
-      "print 'Best classifier:\\n', estimator._best_learner\n",
-      "test_predictions = estimator.predict(X_test)\n",
-      "acc_in_percent = 100 * np.mean(test_predictions == y_test)\n",
-      "print\n",
-      "print 'Prediction accuracy in generalization is %.1f%%' % acc_in_percent"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Best preprocessing pipeline:\n",
-        "PCA(copy=True, n_components=4, whiten=False)\n",
-        "\n",
-        "Best classifier:\n",
-        "KNeighborsClassifier(algorithm=auto, leaf_size=72, metric=euclidean,\n",
-        "           n_neighbors=29, p=2, weights=uniform)\n",
-        "\n",
-        "Prediction accuracy in generalization is 96.7%\n"
-       ]
-      }
-     ],
-     "prompt_number": 5
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAraklEQVR4nO3de5QU1bn38e/DcHFQBiIXucgtBhUjEmCUGA2ieAGMIHoSUYiIUYQo3hJFfY2GZJ3lBc+JaBREZTSiGA8qIkdEQzBIIobhMqBEFMEojDlgEAcEBIbn/aNrxp5xLjVDN13d/fus1Wumqvaufoou5uldVXtvc3dERCR7NUh1ACIiklpKBCIiWU6JQEQkyykRiIhkOSUCEZEsp0QgIpLlkpoIzGygma01s3VmdksV25ub2ctmVmRm75rZ6GTGI1IXIc7fY83sLTP7ysx+WZe6IlFiyepHYGY5wPvAWcBGYClwsbuviStzG9Dc3SeYWWtgLdDW3fckJSiRkEKev22AzsD5wOfufl/YuiJRkswWwUnAOndfH/xhfxYYWqmMA83MzIDDgK3AviTGJBJWreevu29296XA3rrWFYmShkncdwfgk7jljUDfSmV+D8wBioFmwEXuvr/yjsxsDDAG4NBDD+1z7LHHJiVgkWXLln3m7q0Jd/5WJ3RdndtysMSd29+QzERgVayrfB3qHGAlcAZwFPC6mb3p7iUVKrlPA6YB5Ofne2FhYeKjFQHM7J9lv1axOex11NB1dW7LwRJ3bn9DMi8NbQQ6xi0fSeybf7zRwAsesw7YAOgrkURBmPM3GXVFDrpkJoKlQDcz62pmjYHhxC4DxfsYGABgZkcAxwDrkxiTSFhhzt9k1BU56JJ2acjd95nZNcB8IAeY7u7vmtnYYPtU4LfAE2a2mlhzeoK7f5asmETCCnP+mllboBDIA/ab2fXAce5eUlXdlByISAjJvEeAu78CvFJp3dS434uBs5MZg0h9hTh//0Xssk+ouiJRpZ7FIiJZLqktApGDZfaKTUyav5bibbto3yKXm845hvN7dUh1WCJpQYlA0t7sFZu49YXV7NpbCsCmbbu49YXVAEoGIiHo0pCkvUnz15YngTK79pYyaf7aFEUkkl6UCCTtFW/bVaf1IlKREoGkvfYtcuu0XkQqUiKQtHfTOceQ2yinwrrcRjncdM4xKYpIJL3oZrGkvbIbwnpqSKR+lAgkI5zfq4P+8IvUky4NiYhkOSUCEZEsp0QgIpLllAhERLKcEoGISJZTIhARyXJKBCIiWU6JQEQkyyU1EZjZQDNba2brzOyWKrbfZGYrg9c7ZlZqZocnMyYREakoaYnAzHKAh4BBwHHAxWZ2XHwZd5/k7t9z9+8BtwJ/cfetyYpJRES+KZktgpOAde6+3t33AM8CQ2sofzEwM4nxiIhIFZKZCDoAn8QtbwzWfYOZNQUGAs9Xs32MmRWaWeGWLVsSHqiISDZLZiKwKtZ5NWXPA/5a3WUhd5/m7vnunt+6deuEBSgiIskdfXQj0DFu+UiguJqyw9FlIUmS/fv3U1RURHFxMbm5uXz3u9/liCOOSHVYIpGRzESwFOhmZl2BTcT+2F9SuZCZNQdOA0YmMRbJQh9++CH33HMPf/rTn+jWrRutW7dm9+7dvP/++zRt2pSrrrqKUaNG0aCBnqKW7Ja0RODu+8zsGmA+kANMd/d3zWxssH1qUHQY8Jq7f5msWCQ73X777YwbN45HHnkEs4pXKjdv3swzzzzDU089xahRo1IUoUg0mHt1l+2jKT8/3wsLC1MdhmQoM1vm7vmpeG+d25JMNZ3bahNLxtu5cye//e1vufLKKwH44IMPmDt3boqjEokOJQLJeKNHj6ZJkya89dZbABx55JHcfvvtKY5KJDqUCCTjffjhh9x88800atQIgNzcXNLtkqhIMikRSMZr3Lgxu3btKr9h/OGHH9KkSZMURyUSHcl8fFQkEn79618zcOBAPvnkE0aMGMFf//pXCgoKUh2WSGQoEUjGO/vss+nTpw9LlizB3Zk8eTKtWrWqtZ6ZDQQmE3v8+TF3v7vSdgu2DwZ2Ape5+/Jg2w3AFcR6068GRrv77kQel0ii6NKQZLwBAwbQsmVLzj33XH70ox/RqlUrBgwYUGOdMKPnBtu6Ba8xwJSgbgfgWiDf3Y8nlkiGJ/KYRBJJLQLJWLt372bnzp189tlnfP755+U3iEtKSigurm60k3Llo+cCmFnZ6Llr4soMBf7gsR0vMbMWZtYu2NYQyDWzvUBTqh9eRSTllAgkYz3yyCPcf//9FBcX06dPn/JEkJeXx9VXX11b9apGz+0bokwHdy80s/uAj4FdxHrOv1bVm5jZGGKtCTp16hTuwEQSTJeGJGNdd911bNiwgfvuu4/169ezYcMGNmzYQFFREddcc01t1cOMnltlGTP7FrHWQlegPXComVU5lpZG1pUoUItAMt748eN55513WLNmDbt3f32/9tJLL62pWpjRc6srcyawwd23AJjZC8APgBn1PQaRZFIikIw3ceJE3njjDdasWcPgwYOZN28ep556am2JIMzouXOAa4L7B32BL9z9UzP7GPh+MOHSLmAAoEGEJLJ0aUgy3qxZs1iwYAFt27aloKCAoqIivvrqqxrruPs+oGz03H8Az5WNnls2gi7wCrAeWAc8Cvw8qPs2MAtYTuzR0QbAtCQcmkhCqEUgGS83N5cGDRrQsGFDSkpKaNOmDevXr6+1nru/QuyPffy6qXG/O1DlXWd3vxO488AiFzk4lAgk4+Xn57Nt2zauvPJK+vTpw2GHHcZJJ52U6rBEIkOJQDLeww8/DMDYsWMZOHAgJSUlnHDCCSmOSiQ6lAgkYy1fvrzGbb179z6I0YhEV1ITQW1jtQRl+gP3A42Az9z9tGTGJNnjF7/4BRDrYVxYWEjPnj1xd1atWkXfvn1ZvHhxiiMUiYakPTUUZqwWM2sBPAwMcffvAj9OVjySfRYuXMjChQvp3Lkzy5cvp7CwkGXLlrFixQq+853vpDo8kchI5uOj5WO1uPseoGyslniXAC+4+8cA7r45ifFIlnrvvffo0aNH+fLxxx/PypUrUxeQSMQk89JQmLFajgYamdkbQDNgsrv/ofKONB6LHIju3btzxRVXMHLkSMyMGTNm0L1791SHJRIZyUwEYcZqaQj0IdbzMhd4y8yWuPv7FSq5TyPokJOfn685BqVOCgoKmDJlCpMnTwagX79+jBs3LsVRiURHMhNB2LFaPnP3L4EvzWwR0BN4H5EEOeSQQ7jhhhu44YYb9LSQSBWSeY+gfKwWM2tMbKyWOZXKvAT80MwaBuOy9CXWnV8kKa644opUhyASOUlrEbj7PjMrG6slB5heNlZLsH2qu//DzF4FVgH7iT1i+k6yYhIpm5NARL6W1H4EtY3VEixPAiYlMw6RMnfeqeF/RCpTz2LJCkVFRbz55pvlv/fs2TPFEYlEh4ahlow3efJkRowYwebNm9m8eTMjR47kwQcfTHVYIpGhFoFkvMcff5y3336bQw89FIAJEyZw8sknM378+BRHJhINtbYIzKypmf3KzB4NlruZ2Y+SH5pIYrg7OTk55cs5OTm6aSwSJ0yLoABYBpwcLG8E/geYm6ygRBJp9OjR9O3bl2HDhgEwe/ZsLr/88hRHJRIdYRLBUe5+kZldDODuu8ysql7DIpF044030r9/fxYvXoy7U1BQQK9evVIdlkhkhEkEe8wsl2B4CDM7Cqh5wleRCPnpT3/KU089VaFHcdk6EQmXCH4NvAp0NLOngVOA0ckMSiSR3n333QrLpaWlLFu2LEXRiERPrTeL3f014ALgMmAmkO/uC5Mcl8gBu+uuu2jWrBmrVq0iLy+PvLw8mjVrRps2bRg6tPKI6CLZK8xTQwvc/d/u/r/uPtfdPzOzBQcjOJEDceutt7J9+3ZuuukmSkpKKCkpYfv27fz73//mrrvuSnV4IpFR7aUhMzsEaAq0MrNv8fWw0nlA+4MQm0hC6I++SM1qukdwFXA9sT/6y/g6EZQQm4JSREQyQLWJwN0nA5PNbLy7qz++iEiGqvWpIXd/0MyOJzYB/SFx678xpaRIVC1evJgPPviA0aNHs2XLFnbs2EHXrl1THZZIJNSaCMzsTqA/sUTwCjAIWAwoEUhamDhxIoWFhaxdu5bRo0ezd+9eRo4cyV//+tdUhyYSCWFGH/0PYnMK/8vdRxObSrJJUqMSSaAXX3yROXPmlA861759e7Zv357iqESiI0wi2OXu+4F9ZpYHbAa+ndywRBKncePGmBllI6N8+eWXKY5IJFrCJIJCM2sBPErs6aHlwN/D7NzMBprZWjNbZ2a3VLG9v5l9YWYrg9cddQleJIyf/OQnXHXVVWzbto1HH32UM888U3MXi8Sp8R5BMLjcXe6+DZgazC+c5+6ratuxmeUQe8z0LGIjli41sznuvqZS0TfdXcNaS9L88pe/5PXXXycvL4+1a9fym9/8hrPOOqvWemY2EJhMbM7tx9z97krbLdg+GNgJXObuy4NtLYDHgOOJjdN1ubu/lcDDEkmYGhOBu7uZzQb6BMsf1WHfJwHr3H09gJk9CwwFKicCkaSaMGEC99xzT4U//mXrqhPyi8wgoFvw6gtMCX5CLEG86u7/YWaNiXXOFImkMJeGlpjZifXYdwfgk7jljcG6yk42syIzm2dm361qR2Y2xswKzaxwy5Yt9QhFstnrr7/+jXXz5s2rrVr5Fxl33wOUfZGJNxT4g8csAVqYWbvgXlo/4HEAd98TtKpFIinM6KOnA1eZ2T+BL4n1MHZ3P6GWelXNWVB5WqjlQGd332Fmg4HZxL5dVazkPg2YBpCfn6+ppSSUKVOm8PDDD7N+/XpOOOHr03X79u2ccsoptVWv6otM3xBlOgD7gC1AgZn1JHZv7Tp3/8ZdajMbA4wB6NSpU5jDEkm4MIlgUD33vRHoGLd8JFAcX8DdS+J+f8XMHjazVu7+WT3fU6TcJZdcwqBBg7j11lu5++6vL+83a9aMww8/vLbqYb7IVFemIdAbGO/ub5vZZOAW4FffKKwvORIBYXoW/7Oe+14KdDOzrsAmYDhwSXwBM2sL/F9wL+IkYpeq/l3P9xOpoHnz5jRv3pyZM2cCsHnzZnbv3s2OHTvYsWNHbd/Aa/0iU0MZBza6+9vB+lnEEoFIJIW5R1Av7r4PuAaYD/wDeM7d3zWzsWY2Nij2H8A7ZlYEPAAMd80qLgn28ssv061bN7p27cppp51Gly5dGDSo1oZu+ReZ4GbvcGBOpTJzgEst5vvAF+7+qbv/C/jEzI4Jyg1AD0lIhIW5NFRv7v4KsWEp4tdNjfv998DvkxmDyO23386SJUs488wzWbFiBQsXLixvJVTH3feZWdkXmRxgetkXmWD7VGLn9mBgHbHHR+Nn7hsPPB0kkfVoVj+JsNr6EeQA8939zIMUj0jCNWrUiJYtW7J//37279/P6aefzoQJE2qtF+KLjANXV1N3JZB/QIGLHCS19SMoNbOdZtbc3b84WEGJJFKLFi3YsWMH/fr1Y8SIEbRp04aGDZPaGBZJK2H+N+wGVpvZ68QeHwXA3a9NWlQiCfTSSy+Rm5vL7373O55++mm++OIL7rhDo5mIlAmTCP43eImkndLSUoYOHcqf/vQnGjRowKhRo1IdkkjkhHl89MnghtfRwaq17r43uWGJJEZOTg5Nmzbliy++oHnz5qkORySSwkxM0x94EviIWAeajmY2yt0XJTUykQQ55JBD6NGjB2eddVb5nAQADzzwQAqjEomOMJeG/gs4293XApjZ0cBMgoHoRKLu3HPP5dxzz011GCKRFSYRNCpLAgDu/r6ZNUpiTCIJpfsCIjULkwiWmdnjwFPB8ghig2iJiEgGCJMIxhLrNHMtsXsEi4CHkxmUiIgcPLX1LG4ALHP344H/PjghSSLMXrGJSfPXUrxtF+1b5HLTOcdwfq+qpoPIbKWlpdxyyy1MmjQp1aGIRFaNg84Fk9YXmZkGSk8js1ds4tYXVrNp2y4c2LRtF7e+sJrZKzalOrSDLicnh2XLlqGxDEWqF+bSUDvgXTP7OxV7Fg9JWlRyQCbNX8uuvaUV1u3aW8qk+WuzslXQq1cvhg4dyo9//OMKj49ecMEFKYxKJDrCJIKJSY9CEqp42646rc90W7dupWXLlvz5z38uX2dmSgQigTD3CB4K7hFImmjfIpdNVfzRb98iNwXRpF5BQUGqQxCJNN0jyEA3nXMMuY1yKqzLbZTDTeccU02NzLZx40aGDRtGmzZtOOKII7jwwgvZuHFjqsMSiYwwM5SV3SNYYGZzyl7JDkzq7/xeHbjrgh50aJGLAR1a5HLXBT2y8v4AwOjRoxkyZAjFxcVs2rSJ8847j9GjNU+MSJmk3iMws4HAZGIzPD3m7ndXU+5EYAlwkbvPqu/7ydfO79Uha//wV7Zly5YKf/gvu+wy7r///tQFJBIxtbYI3P0vxAacaxT8vhRYXlu9YHazh4BBwHHAxWZ2XDXl7iE2JaBIwrVq1YoZM2ZQWlpKaWkpM2bMoGXLlqkOSyQyak0EZnYlMAt4JFjVAZgdYt8nAevcfb277wGeBYZWUW488DywOUzAInU1ffp0nnvuOdq2bUu7du2YNWsW06dPT3VYIpER5tLQ1cT+qL8N4O4fmFmbEPU6AJ/ELW8E+sYXMLMOwDDgDODE6nZkZmOAMQCdOum+tYRXWlrKbbfdxpw5uq0lUp0wN4u/Cr7RA2BmDYEw3TStinWV690PTHD30irKfl3JfZq757t7fuvWrUO8tUhMTk4OW7ZsYc+ePbUXFslSYVoEfzGz24BcMzsL+Dnwcoh6G4GOcctHAsWVyuQDz5oZQCtgsJntc/fZIfYvEkqXLl045ZRTGDJkSIWexTfeeGMKoxKJjjCJ4BbgZ8Bq4CrgFeCxEPWWAt3MrCuwCRgOXBJfwN27lv1uZk8Ac5UEJNHat29P+/bt2b9/P9u3b091OCKRE2bO4v3Ao8ErNHffZ2bXEHsaKAeY7u7vmtnYYPvUesQrUielpaV88MEHzJgxI9WhiERWmBZBvbn7K8RaEPHrqkwA7n5ZMmOR7BR/j6Bx48apDkckkpKaCESiQPcIRGqmRCAZT/cIRGpWayIws6OBm4DO8eXd/YwkxiWSMHfeeScAX375ZYUWgYjEhOlH8D/EhpS4nVhCKHuJpIW33nqL4447ju7duwNQVFTEz3/+8xRHJRIdYS4N7XP3KUmPRCRJrr/+eubPn8+QIbFJ9Xr27MmiRYtSHJVIdIRpEbxsZj83s3ZmdnjZK+mRiSRQx44dKyzn5ORUU1Ik+4RJBKOIXQr6G7AseBUmMyiRROrYsSN/+9vfMDP27NnDfffdV36ZqCZmNtDM1prZOjO7pYrtZmYPBNtXmVnvSttzzGyFmc1N4OGIJFyYDmVdaysjEmVTp07luuuuY9OmTRx55JGcffbZPPTQQzXWiRtG/Sxiw6UsNbM57r4mrtggoFvw6gtMoeLAitcB/wDyEnc0IokX5qmhRsA4oF+w6g3gEXffm8S4RBKmVatWPP3003WtVj6MOoCZlQ2jHp8IhgJ/cHcHlphZCzNr5+6fmtmRwLnAfwLqsCCRFubS0BSgD/Bw8OoTrBPJZFUNo155yreaytwP3Azsr+lNzGyMmRWaWeGWLVsOKGCR+grz1NCJ7t4zbvnPZlaUrIBEIiLMMOpVljGzHwGb3X2ZmfWv6U3cfRowDSA/Pz/M8O4iCRemRVBqZkeVLZjZt4Ea5w8QyQBhhlGvrswpwBAz+4jYzHxnmJlGvZPICtMiuAlYaGbriX0D6gyMrrmKSHR89dVXPP/883z00Ufs27evfP0dd9xRU7Vah1EH5gDXBPcP+gJfuPunwK3Bi6BF8Et3H5mYoxFJvDBPDS0ws27AMcQSwXvu/lXSIxNJkKFDh9K8eXP69OlDkyZNQtUJOYz6K8BgYB2wE31BkjRVbSIwszPc/c9mdkGlTUeZGe7+QpJjE0mIjRs38uqrr9a5Xm3DqAdPC11dyz7eIPaknUhk1dQiOA34M3BeFdscUCKQtPCDH/yA1atX06NHj1SHIhJJ1SYCd78z+PU37r4hfltw3VQkLSxevJgnnniCrl270qRJE9wdM2PVqlWpDk0kEsLcLH4e6F1p3Sxi/QlqZGYDgcnErrE+5u53V9o+FPgtsWet9wHXu/viEDGJhDZv3rxUhyASaTXdIzgW+C7QvNJ9gjzgkNp2HLKL/gJgjru7mZ0APAccW/fDEKle586dKSoq4s033wTghz/8IT179qyllkj2qKkfwTHAj4AWxO4TlL16A1eG2Hd5F31330Pseeqh8QXcfUdwww3gUL7ZYUfkgE2ePJkRI0awefNmNm/ezMiRI3nwwQdTHZZIZNR0j+Al4CUzO9nd36rHvqvqft+3ciEzGwbcBbQhNjbLN5jZGGAMQKdOneoRimSzxx9/nLfffrt8drIJEyZw8sknM378+BRHJhINYe4RrDCzq4ldJiq/JOTul9dSL0wXfdz9ReBFM+tH7H7BmVWUUTd8qTd3rzD/QE5ODl83REUkTCJ4CngPOAf4DTCC2NC6tQnTRb+cuy8ys6PMrJW7fxZi/yKhjB49mr59+zJs2DAAZs+ezc9+9rMURyUSHWESwXfc/cdmNtTdnzSzZ4j1tqxNrV30zew7wIfBzeLeQGPg33U7BJGa3XjjjfTv35/Fixfj7hQUFNCrV69UhyUSGWESQdm8A9vM7HjgX0CX2iqF7KJ/IXCpme0FdgEXudrskiAlJSXk5eWxdetWunTpQpcuXcq3bd26lcMP14yrIhAuEUwzs28BvyI2yNZhQI2jdZUJ0UX/HuCe0NGK1MEll1zC3Llz6dOnD2Zf37Iq61C2fv36FEYnEh1hBp17LPj1L8C3kxuOSOLMnRubKnjDhg21lBTJbjV1KKtxej13/+/EhyOSeAMGDGDBggW1rhPJVjW1CJoFP48BTiR2WQhincoWJTMokUTYvXs3O3fu5LPPPuPzzz8vf2S0pKSE4uJqH2ATyTo1dSibCGBmrwG93X17sPxr4H8OSnQiB+CRRx7h/vvvp7i4mD59+pQngry8PK6+usbRo0WySpibxZ2APXHLewjx1JBIql133XVcd911PPjgg+pFLFKDsB3K/m5mLxLrGTwM+ENSoxJJoPHjx/POO++wZs0adu/eXb7+0ksvTWFUItER5qmh/zSzecAPg1Wj3X1FcsMSSZyJEyfyxhtvsGbNGgYPHsy8efM49dRTlQhEAtWOPmpmecHPw4GPiLUMngL+GawTSQuzZs1iwYIFtG3bloKCAoqKivjqK027LVKmphbBM8SGoV5GxcHiLFhWnwJJC7m5uTRo0ICGDRtSUlJCmzZt1JlMJE5NTw39KPipaSklreXn57Nt2zauvPJK+vTpw2GHHcZJJ52U6rBEIqOmDmWVp6eswN2XJz4ckcR7+OGHARg7diwDBw6kpKSEE044IcVRiURHTZeG/quGbQ6ckeBYRBJq+fLqv6ssX76c3r1r/K4jkjVqujR0+sEMRCTRfvGLXwCxHsaFhYX07NkTd2fVqlX07duXxYsXpzhCkWgI04+AYPjp46g4Q5n6EkikLVy4EIDhw4czbdo0evToAcA777zDfffdl8rQRCKl1kRgZncC/YklgleAQcBi1KlM0sR7771XngQAjj/+eFauXJm6gEQiJkyL4D+AnsAKdx9tZkcAj9VSRyQyunfvzhVXXMHIkSMxM2bMmEH37t1THZZIZIRJBLvcfb+Z7Qs6mW1GfQgkjRQUFDBlyhQmT54MQL9+/Rg3blyKoxKJjjCJoNDMWgCPEutctgP4e5idm9lAYDKxqSofc/e7K20fAUwIFncA49y9KFzoIuEccsgh3HDDDdxwww2pDkUkkmrqR/B74Bl3/3mwaqqZvQrkufuq2nZsZjnAQ8BZwEZgqZnNcfc1ccU2AKe5++dmNgiYBvSt57GIVPCTn/yE5557jh49elSYqrLMqlW1nsYiWaGmFsEHwH+ZWTvgj8BMd19Zh32fBKxz9/UAZvYsMBQoTwTu/re48kuAI+uw/4wze8UmJs1fS/G2XbRvkctN5xzD+b06pDqstFV2Kahsysq6CtGitWD7YGAncJm7LzezjsQepmgL7Aemufvkeh6GSNLV1I9gMjDZzDoDw4ECMzsEmAk86+7v17LvDsAnccsbqfnb/s+AeVVtMLMxwBiATp061fK26Wn2ik3c+sJqdu0tBWDTtl3c+sJqACWDemrXrh0AnTt3rnPdkC3aQUC34NUXmBL83Af8IkgKzYBlZvZ6pboikVHt6KNl3P2f7n6Pu/cCLiE2H8E/Quz7m23xioPXfV3Q7HRiiWBCVdvdfZq757t7fuvWrUO8dfqZNH9teRIos2tvKZPmr01RROmvWbNm5OXlfeNVtr4W5S1ad98DlLVo4w0F/uAxS4AWZtbO3T8tG4IlmNnvH8S+GIlEUph+BI2AgcRaBQOAvwATQ+x7I9AxbvlI4BsTxZrZCcQeRx3k7v8Osd+MVLxtV53WS+22b99+INXDtGirKtMB+LRshZl1AXoBb1f1JtnQ2pXoq+lm8VnAxcC5xJ4SehYY4+5fhtz3UqCbmXUFNhFLJJdUeo9OwAvAT0Ncaspo7VvksqmKP/rtW+SmIJrMtHnz5gozlNXyhzdMi7bGMmZ2GPA8cL27l1T1Ju4+jdhDEuTn51fZYhZJtpouDd0GvAV0d/fz3P3pOiQB3H0fcA0wn1jT+Dl3f9fMxprZ2KDYHUBL4GEzW2lmhfU7jPR30znHkNsop8K63EY53HTOMSmKKHPMmTOHbt260bVrV0477TS6dOnCoEGDaqsWpkVbbZmgJf088LS7v3BAByCSZEkddM7dXyE2LEX8uqlxv18BXHGg75MJym4I66mhxPvVr37FkiVLOPPMM1mxYgULFy5k5syZtVWrtUULzAGuCZ6I6wt84e6fBk8TPQ78w93/O7FHI5J4oQadk4Pj/F4d9Ic/CRo1akTLli3Zv38/+/fv5/TTT2fChCqfSyjn7vvMrKxFmwNML2vRBtunEvuSMxhYR+zx0dFB9VOAnwKrzWxlsO624IuRSOQoEUjGa9GiBTt27KBfv36MGDGCNm3a0LBh7ad+iBatA1dXUW8xVd8/EImkWh8fFUlXs2bNYvfu3bz00ks0bdqU3/3udwwcOJCjjjqKl19+OdXhiUSGEoFkrKeffppOnToxbtw45s+fj5kxatQorr32Wlq2bJnq8EQiQ4lAMtaLL77IunXrGDBgAA888AAdO3Zk3LhxLFq0KNWhiUSKEoFktLy8PEaNGsW8efNYvXo13/ve9xg/fjwdO3asvbJIltDN4ipo8LfoSNRn8fnnn/PCCy/wxz/+ka1bt3LhhRcmIVqR9KREUIkGf4uOA/0stm/fzuzZs5k5cybLly9nyJAh3H777Zx++ulVDkstkq2UCCqpafA3JYKD60A/i65du3LOOecwbtw4Bg4cSKNGjZIVqkhaUyKoRIO/RceBfhYff/wxTZs2TWRIIhlJN4srqW6QNw3+dvAd6GcxfPhw5s6dy969e7+xbf369dxxxx1Mnz79gGIUyQRKBJVo8LfoONDPYtq0aSxatIhjjz2WE088kcGDB3PGGWfw7W9/m6uuuoo+ffpw+eWXJyN0kbSiS0OVaPC36DjQz6Jt27bce++93HvvvXz00Ud8+umn5ObmcvTRR+uSkUgcJYIqaPC36EjUZ9GlSxe6dOly4AGJZCBdGpKM9/zzz9OtWzeaN29el6kqRbKGWgSS8SZMmMDLL79M9+7dUx2KSCSpRSAZ74gjjlASEKlBUlsEZjYQmExsYo/H3P3uStuPBQqA3sD/c/f7khmPZKf8/Hwuuugizj//fJo0aVK+/oILLkhhVCLRkbREYGY5wEPAWcTmdl1qZnPcfU1csa3AtcD5yYojmTQmUXooKSmhadOmvPbaa+XrzEyJQCSQzBbBScA6d18PEMzrOhQoTwTuvhnYbGbnJjGOpNCYROmjoKAg1SGIRFoyE0EH4JO45Y3EJviuMzMbA4wB6NSp04FHlgAakyj67r33Xm6++WbGjx9f5SBzDzzwQAqiEomeZCaCqoZ39PrsyN2nAdMA8vPz67WPRNOYRNFXdoM4Pz8/xZGIRFsyE8FGIH72jyOB4iS+30HVvkUum6r4o68xiaLjvPPOA2DUqFEpjkQk2pL5+OhSoJuZdTWzxsBwYE4S3++g0phE6aOwsJBhw4bRu3dvTjjhhPKXiMQkrUXg7vvM7BpgPrHHR6e7+7tmNjbYPtXM2gKFQB6w38yuB45z95JkxZUoGpMofYwYMYJJkybRo0cPGjRQ1xmRypLaj8DdXwFeqbRuatzv/yJ2ySgtaUyi9NC6dWuGDBmS6jBEIktDTEjGmzhxIldccQUDBgxQhzKRKigRSMYrKCjgvffeY+/eveWXhtShTORrSgSS8YqKili9enWqwxCJLN05k4z3/e9/nzVr1tReUCRLqUUgGW/x4sU8+eSTdO3alSZNmuDumBmrVq1KdWgikZBViSBVg8Ql8n0TfQxh95focgfTq6++mtL3F4m6rEkEqRokLpHvm+hjCLu/RJc72Dp37pyy9xZJB1lzj6CmQeLS5X0TfQxh95focunCzAaa2VozW2dmt1Sx3czsgWD7KjPrHbauSJRkTSJI1SBxiXzfRB9D2P0lulw6iJtPYxBwHHCxmR1XqdggoFvwGgNMqUNdkcjImktDqRokLpHvm+hjCLu/RJdLE7XOpxEs/8HdHVhiZi3MrB3QJUTd0Ca+/C5riiM/6opEwHHt87jzvO/WuV7WtAhSNUhcIt830ccQdn+JLpcmqppPo/KNjurKhKkLxObaMLNCMyvcsmXLAQctUh9Z0yJI1SBxiXzfRB9D2P0lulyaCDOfRnVlQs/FEWaujfp8wxOpi6xJBJC6QeIS+b6JPoaw+0t0uTQQZj6N6so0DlFXJDKy5tKQSB2FmU9jDnBp8PTQ94Ev3P3TkHVFIiOrWgQiYYWZT4PYEOuDgXXATmB0TXVTcBgioSgRiFQjxHwaDlwdtq5IVOnSkIhIlktqi8DMBgKTiTWPH3P3uyttt2D7YGJN68vcfXld3yeK49tIzVLxmek8Eala0hJBXO/Ks4g9XbHUzOa4e3ynmviemX2J9czsW5f3ier4NlK9VHxmOk9EqpfMS0PlPTPdfQ9Q1rsyXnnPTHdfApT1zAwt08a3yQap+Mx0nohUL5mJ4EB6ZlZQU+/LTBrfJluk4jPTeSJSvWQmggPpmVlxhfs0d8939/zWrVtX2FbdODZpOr5NVkjFZ6bzRKR6yUwEB9IzM7QMG98mK6TiM9N5IlK9ZD41VN67EthErHflJZXKzAGuCUZn7MvXPTNDy7DxbbJCKj4znSci1UtaIjiQnpl1lUHj22SNVHxmOk9EqpbUfgQH0jNTREQODvUsFhHJckoEIiJZTolARCTLKRGIiGQ5i92vTR9mtgX4ZzWbWwGfHcRwkiUTjiNdj6Gzu7euvVji1XJup4t0/dxrkwnHVe25nXaJoCZmVuju+amO40BlwnFkwjFI3WXq556px1VGl4ZERLKcEoGISJbLtEQwLdUBJEgmHEcmHIPUXaZ+7pl6XECG3SMQEZG6y7QWgYiI1JESgYhIlsuYRGBmA81srZmtM7NbUh1PfZjZR2a22sxWmllhquMJy8ymm9lmM3snbt3hZva6mX0Q/PxWKmOU5EvX8zdetp7LGZEIzCwHeAgYBBwHXGxmx6U2qno73d2/l2bPLD8BDKy07hZggbt3AxYEy5L50vH8jfcEWXguZ0QiAE4C1rn7enffAzwLDE1xTFnD3RcBWyutHgo8Gfz+JHD+wYxJpD6y9VzOlETQAfgkbnljsC7dOPCamS0zszGpDuYAHVE221zws02K45Hky6TzN17Gn8tJnZjmILIq1qXjc7GnuHuxmbUBXjez94JvKCLpQOdvmsqUFsFGoGPc8pFAcYpiqTd3Lw5+bgZeJHbJK139n5m1Awh+bk5xPJJkGXb+xsv4czlTEsFSoJuZdTWzxsBwYE6KY6oTMzvUzJqV/Q6cDbxTc61ImwOMCn4fBbyUwlgkyTLw/I2X8edyRlwacvd9ZnYNMB/IAaa7+7spDquujgBeNDOIfS7PuPurqQ0pHDObCfQHWpnZRuBO4G7gOTP7GfAx8OPURSgHQdqev/Gy9VzWEBMiIlkuUy4NiYhIPSkRiIhkOSUCEZEsp0QgIpLllAhERLKcEkHEmNmO4GcXM7skwfu+rdLy3xK5f5Ga6NyOLiWC6OoC1Ok/SzAKa00q/Gdx9x/UMSaRROiCzu1IUSKIrruBHwZju99gZjlmNsnMlprZKjO7CsDM+pvZQjN7BlgdrJsdDPz1btngX2Z2N5Ab7O/pYF3ZNzQL9v1OMJ78RXH7fsPMZpnZe2b2tAU9hkQOgM7tqHF3vSL0AnYEP/sDc+PWjwFuD35vAhQCXYNyXwJd48oeHvzMJdbNv2X8vqt4rwuB14n1yj6CWO/JdsG+vyA2dlMD4C3g1FT/G+mVni+d29F9qUWQPs4GLjWzlcDbQEugW7Dt7+6+Ia7stWZWBCwhNhhfN2p2KjDT3Uvd/f+AvwAnxu17o7vvB1YSa9aLJJLO7RTLiLGGsoQB4919foWVZv2JfWuKXz4TONndd5rZG8AhIfZdna/ifi9F54wkns7tFFOLILq2A83ilucD48ysEYCZHR2M8lhZc+Dz4D/KscD347btLatfySLgouBabWugH/D3hByFyDfp3I6YrM2AaWAVsC9oBj8BTCbWdF0e3NTaQtVT5r0KjDWzVcBaYk3oMtOAVWa23N1HxK1/ETgZKCI2oc/N7v6v4D+bSKLp3I4YjT4qIpLldGlIRCTLKRGIiGQ5JQIRkSynRCAikuWUCEREspwSgYhIllMiEBHJcv8fG49guGYWlW4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Demo version of estimator.fit()\n",
+    "fit_iterator = estimator.fit_iter(X_train,y_train)\n",
+    "fit_iterator.__next__()\n",
+    "plot_helper = hpsklearn.demo_support.PlotHelper(estimator,\n",
+    "                                                mintodate_ylim=(-.01, .10))\n",
+    "while len(estimator.trials.trials) < estimator.max_evals:\n",
+    "    fit_iterator.send(1) # -- try one more model\n",
+    "    plot_helper.post_iter()\n",
+    "plot_helper.post_loop()\n",
+    "\n",
+    "# -- Model selection was done on a subset of the training data.\n",
+    "# -- Now that we've picked a model, train on all training data.\n",
+    "estimator.retrain_best_model_on_full_data(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best preprocessing pipeline:\n",
+      "StandardScaler()\n",
+      "\n",
+      "\n",
+      "Best classifier:\n",
+      " RandomForestClassifier(bootstrap=False, max_features='sqrt', min_samples_leaf=3,\n",
+      "                       n_estimators=1676, n_jobs=1, random_state=4,\n",
+      "                       verbose=False)\n",
+      "\n",
+      "\n",
+      "Prediction accuracy in generalization is 93.3%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Best preprocessing pipeline:')\n",
+    "for pp in estimator._best_preprocs:\n",
+    "    print(pp)\n",
+    "print('\\n')\n",
+    "print('Best classifier:\\n', estimator._best_learner)\n",
+    "test_predictions = estimator.predict(X_test)\n",
+    "acc_in_percent = 100 * np.mean(test_predictions == y_test)\n",
+    "print('\\n')\n",
+    "print('Prediction accuracy in generalization is %.1f%%' % acc_in_percent)"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
**Demo-Iris:**
- Update notebook to version 4. 
- Remove `skdata.iris.view` in favour of `sklearn.datasets.load_iris`.
- Use pandas dataframe to better simulate a real-world application.
- `Generator().next()` has been renamed to `Generator().__next__()`.
- Rewrote print statements to match Python3 format.