### PR TITLE
Specify encoding option for open function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author = 'James Bergstra',
     author_email = 'anon@anon.com',
     description = 'Hyperparameter Optimization for sklearn',
-    long_description = open('README.md').read(),
+    long_description = open('README.md', encoding='utf-8').read(),
     keywords = ['hyperopt', 'hyperparameter', 'sklearn'],
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
UnicodeDecodeError occured during installation.
Fixed: Specify encoding option for [`open`](https://github.com/HuangChenChia/hyperopt-sklearn/blob/new_branch/setup.py#L24) function.