### PR TITLE
Fix setup.cfg issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 
 [options]
 packages =
-    hpsklearn
+    find:
 install_requires =
     hyperopt>=0.2.5
     numpy>=1.21.2


### PR DESCRIPTION
Resolves issue where no subdirectories would be downloaded when using `pip install git+...`.

Fixes #185 


Please review asap. Will merge without review 24 hours from now. Since `hyperopt-sklearn` is currently unusable.