### PR TITLE
scope.int max_iter param _coordinate_descent

### DIFF
--- a/hpsklearn/components/linear_model/_coordinate_descent.py
+++ b/hpsklearn/components/linear_model/_coordinate_descent.py
@@ -81,7 +81,7 @@ def _coordinate_descent_max_iter(name: str):
     """
     Declaration search space 'max_iter' parameter
     """
-    return hp.uniform(name, low=800, high=1200)
+    return scope.int(hp.uniform(name, low=800, high=1200))
 
 
 def _coordinate_descent_tol(name: str):


### PR DESCRIPTION
This commit adds missing `scope.int` to `max_iter` parameter to _coordinate_descent file