### PR TITLE
update scikit-learn requirements to force version below 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 hyperopt>=0.2.6
 numpy>=1.21.2
-scikit-learn>=1.0
+scikit-learn>=1.0,<1.2
 scipy>=1.7.1
 pandas>=1.3.3


### PR DESCRIPTION
Modified the scikit-learn entry to force a version below 1.2 to avoid error with AdaBoostClassifier.