### PR TITLE
Add upper bounds on dependecies to setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,10 @@ classifiers =
 packages =
     find:
 install_requires =
-    hyperopt>=0.2.6
-    numpy>=1.26.0
-    scikit-learn>=1.3.0
-    scipy>=1.11.2
+    hyperopt>=0.2.6,<=0.2.7
+    numpy>=1.26.0,<1.26.1
+    scikit-learn>=1.3.0,<=1.3.2
+    scipy>=1.11.2,<1.11.3
 python_requires = >=3.9
 zip_safe = False
 


### PR DESCRIPTION
Hello

We are using hyperopt-sklearn in Databricks environment, installing using `pip install git+https://github.com/hyperopt/hyperopt-sklearn ` pulls in numpy 2.0, which in Databricks, but I guess possibly elsewhere, breaks a lot of things. This is because the `setup.cfg` does not contain the same upper bounds on packages as `requirements.txt` 

I have simply updated the `setup.cfg` to be consistent with `requirements.txt`, if you think different upper bounds should be tested and used I can invest some time into it.

I'm also curious why pandas is not listed as dependency in `setup.cfg`?

