### PR TITLE
FIX: Fix broken readme links and setup.cfg Development Status tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # hyperopt-sklearn
 
-[Hyperopt-sklearn](http://hyperopt.github.com/hyperopt-sklearn/) is
-[Hyperopt](http://hyperopt.github.com/hyperopt)-based model selection among machine learning algorithms in
-[scikit-learn](http://scikit-learn.org/).
+[Hyperopt-sklearn](https://github.com/hyperopt/hyperopt-sklearn) is
+[Hyperopt](https://github.com/hyperopt/hyperopt)-based model selection among machine learning algorithms in
+[scikit-learn](https://scikit-learn.org/).
 
-See how to use hyperopt-sklearn through [examples](http://hyperopt.github.io/hyperopt-sklearn/#documentation)
-More examples can be found in the Example Usage section of the SciPy paper
+See how to use hyperopt-sklearn through [examples](https://hyperopt.github.io/hyperopt-sklearn/#documentation).
+More examples can be found in the Example Usage section of the SciPy paper:
 
-Komer B., Bergstra J., and Eliasmith C. "Hyperopt-Sklearn: automatic hyperparameter configuration for Scikit-learn" Proc. SciPy 2014. http://conference.scipy.org/proceedings/scipy2014/pdfs/komer.pdf
+Komer B., Bergstra J., and Eliasmith C. "Hyperopt-Sklearn: automatic hyperparameter configuration for Scikit-learn" Proc. SciPy 2014. https://proceedings.scipy.org/articles/Majora-14bd3278-006
 
 ## Installation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
-name = hpsklearn-compneurobilbao
+name = hpsklearn
 version = 1.0.3
-description = Hyperparameter Optimization for sklearn, compneurobilbaolab unofficial version.
+description = Hyperparameter Optimization for sklearn
 long_description = file: README.md
-url = https://github.com/compneurobilbao/hyperopt-sklearn
-author = {James Bergstra, Iñigo Tellaetxe Elorriaga}
-author_email = compneurobilbaolab@gmail.com
+url = http://hyperopt.github.com/hyperopt-sklearn/
+author = James Bergstra
+author_email = anon@anon.com
 license = BSD
 license_file = LICENSE.txt
 platforms = Linux, OS-X, Windows

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,17 @@
 [metadata]
-name = hpsklearn
+name = hpsklearn-compneurobilbao
 version = 1.0.3
-description = Hyperparameter Optimization for sklearn
+description = Hyperparameter Optimization for sklearn, compneurobilbaolab unofficial version.
 long_description = file: README.md
-url = http://hyperopt.github.com/hyperopt-sklearn/
-author = James Bergstra
-author_email = anon@anon.com
+url = https://github.com/compneurobilbao/hyperopt-sklearn
+author = {James Bergstra, Iñigo Tellaetxe Elorriaga}
+author_email = compneurobilbaolab@gmail.com
 license = BSD
 license_file = LICENSE.txt
 platforms = Linux, OS-X, Windows
 keywords = hyperopt, hyperparameter, sklearn
 classifiers =
-    Development Status :: 1.0.3 - Alpha
+    Development Status :: 3 - Alpha
     Intended Audience :: Education
     Intended Audience :: Science/Research
     Intended Audience :: Developers


### PR DESCRIPTION
### Key Changes
- Made all links in README `https` instead of `http`.
- Updated all links in README to working links, previous were broken.
- Modified `setup.cfg` Development Status tag to a supported value.